### PR TITLE
Docs (Repo Readme): Update the dgraph-docs repo readme file and PULL_REQUEST_TEMPLATE.md with contributor guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@ Title: Please use the following format for your PR title:  topic(area): details
 - The "topic" should be one of the following: Docs, Nav or Chore
 - The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
 Sample Titles:
-  Docs (GraphQL): Document the @deprecated annotation
-  Chore (Other): cherry-pick updates from master to release/v20.11
+  Docs(GraphQL): Document the @deprecated annotation
+  Chore(Other): cherry-pick updates from master to release/v20.11
 
 Description: Please include the following in your PR description:
 1. A brief, clear description of the change.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ Description: Please include the following in your PR description:
 2. Link to any related PRs or discuss.dgraph.io posts.
 3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
 3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
+4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.
 
 Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,17 @@
 
 <!--
-Your title must be in the following format: topic(area): details
-- The "topic" should be be one of the following: Docs, Nav or Chore
-- The "area" is the feature (i.e., GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
-
+Title: Please use the following format for your PR title:  topic(area): details
+- The "topic" should be one of the following: Docs, Nav or Chore
+- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
 Sample Titles:
-Docs (GraphQL): Document the @deprecated annotation Chore (Other): cherry-pick updates from master to release/v20.11
+  Docs (GraphQL): Document the @deprecated annotation
+  Chore (Other): cherry-pick updates from master to release/v20.11
 
-Please develop in the `master` branch when you can, so that we cherry-pick out of `master`, not into `master`.
-
-Please add a description with these things:
-1. A brief, clear description explaining the problem and what you changed.
+Description: Please include the following in your PR description:
+1. A brief, clear description of the change.
 2. Link to any related PRs or discuss.dgraph.io posts.
 3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
 3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
+
+Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,17 @@
 
 <!--
-Your title must be in the following format: topic(Area): Feature
-Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test
+Your title must be in the following format: topic(area): details
+- The "topic" should be be one of the following: Docs, Nav or Chore
+- The "area" is the feature (i.e., GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
 
 Sample Titles:
-feat(Enterprise): Backups can now get credentials from IAM
-fix(Query): Skipping floats that cannot be Marshalled in JSON
-perf: [Breaking] json encoding is now 35% faster if SIMD is present
-chore: all chores/tests will be excluded from the CHANGELOG
+Docs (GraphQL): Document the @deprecated annotation Chore (Other): cherry-pick updates from master to release/v20.11
+
+Please develop in the `master` branch when you can, so that we cherry-pick out of `master`, not into `master`.
 
 Please add a description with these things:
-1. A good description explaining the problem and what you changed.
-2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
-3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
-4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
+1. A brief, clear description explaining the problem and what you changed.
+2. Link to any related PRs or discuss.dgraph.io posts.
+3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
+3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As a contributor to Dgraph documentation, we ask that you do the following:
 
 ### Technical writing style
 
-Dgraph Labs uses a style guide for our documentation so that we can make it as easy to understand as possible. The [Dgraph Style Guide](https://discuss.dgraph.io/t/dgraph-developer-documentation-style-guide/10955) is a concise style reference for our documentation, but it isn't comprehensive. For anything not found in our style guide, use Google's [Developer Docs Style Guide](https://developers.google.com/style/highlights). The next section has a few quick tips from that style guide.
+Dgraph Labs uses a style guide for our documentation so that we can make it as easy to understand as possible. The [Dgraph Style Guide](https://discuss.dgraph.io/t/dgraph-developer-documentation-style-guide/10955) is a concise style reference for our documentation, but it isn't comprehensive. For anything not found in our style guide, use Google's [Developer Docs Style Guide](https://developers.google.com/style/highlights).
 
 #### Style tips for machine-translatable docs!
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # Dgraph Documentation
 
-If you are looking for Dgraph documentation, you might find https://dgraph.io/docs/ much more readable.
+To read the official Dgraph documentation that is published from this repository
+please see https://dgraph.io/docs/.
 
-## Contributing
+## Contribution guidelines
 
-We use [Hugo](https://gohugo.io/) for our documentation.
+As a contributor to Dgraph documentation, we ask that you do the following:
+- **Label your PR for easy management**: Your PR title should be in the following format: *Topic (area): details*. The topic is either "Docs", "Nav" (aka, navigation), "Mgmt" (repo admin, build) or "Chore" (for cherry-picks). The area is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs (GraphQL): Document the @deprecated annotation* or *Chore (Other): cherry-pick updates from `master` to `release/v20.11`*
+- **Note required cherry-pick(s) in your PR description**: If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "Please cherry-pick to v20.07").
+- **(Dgraph core team only)**: Include the ID of any issues/tickets related to your PR in the description (i.e., "Fixes DGRAPH-12345" or "Per DGRAPH-54321").
+- **Develop in the `master` branch first**: Make any changes applicable to the current (recently-released) version of Dgraph in the `master` branch first, and then cherry-pick those changes to the correct release branch (for example, `release/v20.11`).
 
-### Running locally
+ **Exception**: Changes that *only* apply to older Dgraph versions (for example `release/v20.07`), can occur directly in a release branch, but will not be cherry-picked forward.
+- **Follow technical writing conventions**: As much as possible, please follow technical writing conventions. For example, use the second person ("you") rather than third-person ("the developer") when addressing the reader. Also, choose multiple simpler sentences over longer sentences, when possible. To learn more about these conventions, see Google's [Developer Docs Style Guide](https://developers.google.com/style/highlights).
+- **Link to discuss.dgraph.io posts when applicable**: If your PR is based on discussions on Discuss, feel free to include a link to the relevant discussion in your PR description.
+
+
+### Staging doc updates locally
+
+We use [Hugo](https://gohugo.io/) for our documentation. You can use Hugo to locally stage doc updates before or after creating a PR.
 
 1. Download and install the latest patch of hugo version v0.69.x from [here](https://github.com/gohugoio/hugo/releases/).
 
@@ -16,8 +28,7 @@ We use [Hugo](https://gohugo.io/) for our documentation.
 pushd themes && git clone https://github.com/dgraph-io/hugo-docs && popd
 ```
 
-3. Run `./scripts/local.sh` and visit [http://localhost:1313](http://localhost:1313) to see the
-   documentation site.
+3. Run `./scripts/local.sh` and visit [http://localhost:1313](http://localhost:1313) to see the documentation site running on your local machine.
 
 (Optional) To run queries _within_ the documentation using a different Dgraph instance, set the `DGRAPH_ENDPOINT` environment variable before starting the local web server:
 
@@ -41,7 +52,9 @@ sh scripts/docker.sh
 
 ### Branch
 
-Depending on what branch you are on, some code examples will dynamically change. For instance, go-grpc code examples will have different import path depending on branch name.
+Depending on what branch you are on, some code examples will dynamically change. 
+For example, `go-grpc` code examples will have different import path depending
+on the branch name.
 
 ## Runnable
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,32 @@
 # Dgraph Documentation
 
-To read the official Dgraph documentation that is published from this repository
+To read the official Dgraph documentation that is published from this repository,
 please see https://dgraph.io/docs/.
 
 ## Contribution guidelines
 
 As a contributor to Dgraph documentation, we ask that you do the following:
-- **Label your PR for easy management**: Your PR title should be in the following format: *Topic (area): details*. The topic is either "Docs", "Nav" (aka, navigation), "Mgmt" (repo admin, build) or "Chore" (for cherry-picks). The area is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs (GraphQL): Document the @deprecated annotation* or *Chore (Other): cherry-pick updates from `master` to `release/v20.11`*
-- **Note required cherry-pick(s) in your PR description**: If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "Please cherry-pick to v20.07").
-- **(Dgraph core team only)**: Include the ID of any issues/tickets related to your PR in the description (i.e., "Fixes DGRAPH-12345" or "Per DGRAPH-54321").
+- **Label your PR for easy management**: Your PR title should be in the following format: **Topic (area): details**. The **topic** is either "Docs", "Nav" (aka, navigation), "Mgmt" (repo admin, build) or "Chore" (for cherry-picks). The **area** is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs (GraphQL): Document the @deprecated annotation* or *Chore (Other): cherry-pick updates from `master` to `release/v20.11`*
 - **Develop in the `master` branch first**: Make any changes applicable to the current (recently-released) version of Dgraph in the `master` branch first, and then cherry-pick those changes to the correct release branch (for example, `release/v20.11`).
 
  **Exception**: Changes that *only* apply to older Dgraph versions (for example `release/v20.07`), can occur directly in a release branch, but will not be cherry-picked forward.
-- **Follow technical writing conventions**: As much as possible, please follow technical writing conventions. For example, use the second person ("you") rather than third-person ("the developer") when addressing the reader. Also, choose multiple simpler sentences over longer sentences, when possible. To learn more about these conventions, see Google's [Developer Docs Style Guide](https://developers.google.com/style/highlights).
+- **Note planned cherry-pick(s) in your PR description**: If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.
+
 - **Link to discuss.dgraph.io posts when applicable**: If your PR is based on discussions on Discuss, feel free to include a link to the relevant discussion in your PR description.
 
+- **Technical writing style**: As much as possible, please follow technical writing style conventions. More on this below.
+
+- **(Dgraph core team only)**: Include the ID of any issues/tickets related to your PR in the description (i.e., "Fixes DGRAPH-12345" or "Per DGRAPH-54321").
+
+### Technical writing style
+
+Dgraph Labs uses a style guide for our documentation so that we can make it as easy to understand as possible. Our style guide is based on Google's [Developer Docs Style Guide](https://developers.google.com/style/highlights).
+
+Making our documentation easy to understand includes optimizing it for client-side machine translation into other languages. To help with this, please see the following technical writing style tips:
+- Generally, use the second person ("you") rather than the third-person ("the developer") when addressing the reader.
+- Always use the third person when describing Dgraph database or features (avoid "this lets us" in favor of "this lets Dgraph").
+- Write in present-tense, active voice when you can.
+- Prefer simple sentences to complex and complex-compound sentences.
 
 ### Staging doc updates locally
 
@@ -36,13 +48,13 @@ pushd themes && git clone https://github.com/dgraph-io/hugo-docs && popd
 DGRAPH_ENDPOINT="http://localhost:8080/query?latency=true" ./scripts/local.sh
 ```
 
-Now you can make changes to the docs and see them being updated instantly thanks to Hugo.
+Now you can make changes to the docs and see them being updated instantly, thanks to Hugo.
 
-- While running locally, the version selector does not work because you need to build the documentation and serve it behind a reverse proxy to have multiple versions.
+**Note**: While running locally, the version selector does not work because you need to build the documentation and serve it behind a reverse proxy to have multiple versions.
 
-### Running locally with Docker
+### Running docs locally with Docker
 
-Make sure you have docker-compose.
+Make sure you have docker-compose installed.
 
 Run:
 
@@ -57,6 +69,8 @@ For example, `go-grpc` code examples will have different import path depending
 on the branch name.
 
 ## Runnable
+
+Some code examples are runnable, allowing for reader interaction with a data set.
 
 ### Custom example
 
@@ -77,8 +91,7 @@ Pass custom Go-GRPC example to the runnable by passing a `customExampleGoGRPC` t
 {{< /runnable >}}
 ```
 
-We cannot pass multiline string as an argument to a shortcode. Therefore, we
-have to make the whole custom example in a single line string by replacing newlines with `\n`.
+**Note:** Runnable doesn't support passing a multiline string as an argument to a shortcode. Therefore, you have to create the whole custom example in a single line string by replacing newlines with `\n`.
 
 ### Deployment
 
@@ -86,8 +99,6 @@ Run `./scripts/build.sh` in a tmux window. The script polls `dgraph-io/dgraph` e
 and pulls any new changes that have been merged to any of the branches listed in the script.
 It also rebuilds the site if there are any changes.
 
-Any new version for which docs need to be added should be added to the `VERSIONS_ARRAY` in
-`scripts/build.sh` and the script should be restarted after SSHing into the server.
+To add docs for a new version, add that version to the `VERSIONS_ARRAY` in `scripts/build.sh`. Then, restart the script by connecting to the server using SSH.
 
-If for reason the site is not getting updated after pushing to the main repo, the script might have been
-terminated. SSH into the server and restart it.
+If for some reason the site is not updating after pushing to the main repo, the script might have been terminated. To fix this, SSH into the server and restart it.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ please see https://dgraph.io/docs/.
 ## Contribution guidelines
 
 As a contributor to Dgraph documentation, we ask that you do the following:
-- **Label your PR for easy management**: Your PR title should be in the following format: **Topic (area): details**. The **topic** is either "Docs", "Nav" (aka, navigation), or "Chore" (for build fixes, cherry-picks, etc). The **area** is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs (GraphQL): Document the @deprecated annotation* or *Chore (Other): cherry-pick updates from `master` to `release/v20.11`*
+- **Label your PR for easy management**: Your PR title should be in the following format: **Topic (area): details**. The **topic** is either "Docs", "Nav" (aka, navigation), or "Chore" (for build fixes, cherry-picks, etc). The **area** is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs(GraphQL): Document the @deprecated annotation* or *Chore(Other): cherry-pick updates from `master` to `release/v20.11`*
 - **Develop in the `master` branch first**: Make any changes applicable to the current (recently-released) version of Dgraph in the `master` branch first, and then cherry-pick those changes to the correct release branch (for example, `release/v20.11`).
 
  **Exception**: Changes that *only* apply to older Dgraph versions (for example `release/v20.07`), can occur directly in a release branch, but will not be cherry-picked forward.
@@ -14,19 +14,23 @@ As a contributor to Dgraph documentation, we ask that you do the following:
 
 - **Link to discuss.dgraph.io posts when applicable**: If your PR is based on discussions on Discuss, feel free to include a link to the relevant discussion in your PR description.
 
-- **Technical writing style**: As much as possible, please follow technical writing style conventions. More on this below.
+- **Technical writing style**: As much as possible, please follow technical writing style conventions (More on this below).
 
 - **(Dgraph core team only)**: Include the ID of any issues/tickets related to your PR in the description (i.e., "Fixes DGRAPH-12345" or "Per DGRAPH-54321").
 
 ### Technical writing style
 
-Dgraph Labs uses a style guide for our documentation so that we can make it as easy to understand as possible. Our style guide is based on Google's [Developer Docs Style Guide](https://developers.google.com/style/highlights).
+Dgraph Labs uses a style guide for our documentation so that we can make it as easy to understand as possible. The [Dgraph Style Guide](https://discuss.dgraph.io/t/dgraph-developer-documentation-style-guide/10955) is a concise style reference for our documentation, but it isn't comprehensive. For anything not found in our style guide, use Google's [Developer Docs Style Guide](https://developers.google.com/style/highlights). The next section has a few quick tips from that style guide.
+
+#### Style tips for machine-translatable docs!
 
 Making our documentation easy to understand includes optimizing it for client-side machine translation into other languages. To help with this, please see the following technical writing style tips:
 - Generally, use the second person ("you") rather than the third-person ("the developer") when addressing the reader.
 - Always use the third person when describing Dgraph database or features (avoid "this lets us" in favor of "this lets Dgraph").
 - Write in present-tense, active voice when you can.
 - Prefer simple sentences to complex and complex-compound sentences.
+
+**Note:** Please don't let these style conventions prevent you from creating a  PR to share your contribution to Dgraph Docs! PR reviewers can help with these issues.
 
 ### Staging doc updates locally
 
@@ -68,7 +72,7 @@ Depending on what branch you are on, some code examples will dynamically change.
 For example, `go-grpc` code examples will have different import path depending
 on the branch name.
 
-## Runnable
+## Runnable code examples
 
 Some code examples are runnable, allowing for reader interaction with a data set.
 
@@ -93,12 +97,3 @@ Pass custom Go-GRPC example to the runnable by passing a `customExampleGoGRPC` t
 
 **Note:** Runnable doesn't support passing a multiline string as an argument to a shortcode. Therefore, you have to create the whole custom example in a single line string by replacing newlines with `\n`.
 
-### Deployment
-
-Run `./scripts/build.sh` in a tmux window. The script polls `dgraph-io/dgraph` every one minute
-and pulls any new changes that have been merged to any of the branches listed in the script.
-It also rebuilds the site if there are any changes.
-
-To add docs for a new version, add that version to the `VERSIONS_ARRAY` in `scripts/build.sh`. Then, restart the script by connecting to the server using SSH.
-
-If for some reason the site is not updating after pushing to the main repo, the script might have been terminated. To fix this, SSH into the server and restart it.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ please see https://dgraph.io/docs/.
 ## Contribution guidelines
 
 As a contributor to Dgraph documentation, we ask that you do the following:
-- **Label your PR for easy management**: Your PR title should be in the following format: **Topic (area): details**. The **topic** is either "Docs", "Nav" (aka, navigation), "Mgmt" (repo admin, build) or "Chore" (for cherry-picks). The **area** is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs (GraphQL): Document the @deprecated annotation* or *Chore (Other): cherry-pick updates from `master` to `release/v20.11`*
+- **Label your PR for easy management**: Your PR title should be in the following format: **Topic (area): details**. The **topic** is either "Docs", "Nav" (aka, navigation), or "Chore" (for build fixes, cherry-picks, etc). The **area** is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs (GraphQL): Document the @deprecated annotation* or *Chore (Other): cherry-pick updates from `master` to `release/v20.11`*
 - **Develop in the `master` branch first**: Make any changes applicable to the current (recently-released) version of Dgraph in the `master` branch first, and then cherry-pick those changes to the correct release branch (for example, `release/v20.11`).
 
  **Exception**: Changes that *only* apply to older Dgraph versions (for example `release/v20.07`), can occur directly in a release branch, but will not be cherry-picked forward.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ please see https://dgraph.io/docs/.
 ## Contribution guidelines
 
 As a contributor to Dgraph documentation, we ask that you do the following:
-- **Label your PR for easy management**: Your PR title should be in the following format: **Topic (area): details**. The **topic** is either "Docs", "Nav" (aka, navigation), or "Chore" (for build fixes, cherry-picks, etc). The **area** is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include: *Docs(GraphQL): Document the @deprecated annotation* or *Chore(Other): cherry-pick updates from `master` to `release/v20.11`*
+- **Label your PR for easy management**: Your PR title should be in the following format: **Topic (area): details**. The **topic** is either "Docs", "Nav" (aka, navigation), or "Chore" (for build fixes, cherry-picks, etc). The **area** is the feature (i.e. "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bugfix PRs). So, example PR names include:
+ *Docs(GraphQL): Document the @deprecated annotation* or *Chore(Other): cherry-pick updates from master to release/v20.11*
 - **Develop in the `master` branch first**: Make any changes applicable to the current (recently-released) version of Dgraph in the `master` branch first, and then cherry-pick those changes to the correct release branch (for example, `release/v20.11`).
 
  **Exception**: Changes that *only* apply to older Dgraph versions (for example `release/v20.07`), can occur directly in a release branch, but will not be cherry-picked forward.
@@ -30,7 +31,7 @@ Making our documentation easy to understand includes optimizing it for client-si
 - Write in present-tense, active voice when you can.
 - Prefer simple sentences to complex and complex-compound sentences.
 
-**Note:** Please don't let these style conventions prevent you from creating a  PR to share your contribution to Dgraph Docs! PR reviewers can help with these issues.
+**Note:** Please don't let these style conventions stop you from creating a PR to share your contribution to Dgraph Docs! PR reviewers can help with style guide issues.
 
 ### Staging doc updates locally
 
@@ -54,7 +55,7 @@ DGRAPH_ENDPOINT="http://localhost:8080/query?latency=true" ./scripts/local.sh
 
 Now you can make changes to the docs and see them being updated instantly, thanks to Hugo.
 
-**Note**: While running locally, the version selector does not work because you need to build the documentation and serve it behind a reverse proxy to have multiple versions.
+**Note**: While running locally, the version selector does not work because you need to build the documentation and serve it behind a reverse proxy to have multiple versions. Also, formatting of lists is less fussy when running locally; so please precede lists with a blank line in your PR.
 
 ### Running docs locally with Docker
 


### PR DESCRIPTION
This PR updates the dgraph-docs repo with a new readme and pull request template that provides more detailed contributor guidelines, including:
- How to title PRs
- Information to include in the description
- Which branches to target for doc development (use `master` when possible)
- Style guide information
- Minor edits throughout
- Removed outdated "deployment" section

Fixes DGRAPH-2917
Cherry-Pick to all release/* branches.

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs (GraphQL): Document the @deprecated annotation
  Chore (Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in the PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.

Note: Create and edit docs in the `master` branch when you can, so that we cherry-pick out of `master`, not into `master`.
-->