### PR TITLE
chore: Automate the versioning docs based on Github API

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,7 +27,6 @@ HUGO="${HUGO:-hugo}"
 OLD_THEME="${OLD_THEME:-old-theme}"
 NEW_THEME="${NEW_THEME:-master}"
 
-# TODO - Maybe get list of released versions from Github API and filter
 # those which have docs.
 
 # Place the latest version at the beginning so that version selector can
@@ -35,11 +34,12 @@ NEW_THEME="${NEW_THEME:-master}"
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 
+getMajorVersions=$(curl -s https://get.dgraph.io/latest | grep -o '"majorReleases":.*]' | grep -o '".*"' |  grep -o '"[^[]*$' | sed  "s/\"/\'/g"  | sed  "s/\,/ /g" | sed  "s/'v20.03'/ /g")
+
 # these versions use new theme
 NEW_VERSIONS=(
-        'v20.11'
         'master'
-        'v20.07'
+		$getMajorVersions
 )
 
 # these versions use old theme

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,22 +34,24 @@ NEW_THEME="${NEW_THEME:-master}"
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 
-getMajorVersions=$(curl -s https://get.dgraph.io/latest | grep -o '"majorReleases":.*]' | grep -o '".*"' |  grep -o '"[^[]*$' | sed  "s/\"//g"  | sed  "s/\,/ /g" | sed  "s/v20.03/ /g")
+getMajorVersions=$(curl -s https://get.dgraph.io/latest \
+| grep -o '"majorReleases":.*]' | grep -o '".*"' |  grep -o '"[^[]*$' \
+| sed  "s/\"//g"  | sed  "s/\,/ /g" | sed  "s/v20.03/ /g")
 
 MAJOR_VERSIONS=(
-		$getMajorVersions
+  $getMajorVersions
 )
 
 # these versions use new theme
 NEW_VERSIONS=(
-	    ${MAJOR_VERSIONS:0}
-        'master'
-		${MAJOR_VERSIONS[@]:1}
+  ${MAJOR_VERSIONS:0}
+  'master'
+  ${MAJOR_VERSIONS[@]:1}
 )
 
 # these versions use old theme
 OLD_VERSIONS=(
-	'v20.03'
+  'v20.03'
 )
 
 VERSIONS_ARRAY=("${NEW_VERSIONS[@]}" "${OLD_VERSIONS[@]}")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,12 +34,17 @@ NEW_THEME="${NEW_THEME:-master}"
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 
-getMajorVersions=$(curl -s https://get.dgraph.io/latest | grep -o '"majorReleases":.*]' | grep -o '".*"' |  grep -o '"[^[]*$' | sed  "s/\"/\'/g"  | sed  "s/\,/ /g" | sed  "s/'v20.03'/ /g")
+getMajorVersions=$(curl -s https://get.dgraph.io/latest | grep -o '"majorReleases":.*]' | grep -o '".*"' |  grep -o '"[^[]*$' | sed  "s/\"//g"  | sed  "s/\,/ /g" | sed  "s/v20.03/ /g")
+
+MAJOR_VERSIONS=(
+		$getMajorVersions
+)
 
 # these versions use new theme
 NEW_VERSIONS=(
+	    ${MAJOR_VERSIONS:0}
         'master'
-		$getMajorVersions
+		${MAJOR_VERSIONS[@]:1}
 )
 
 # these versions use old theme


### PR DESCRIPTION
This will collect the major versions from https://get.dgraph.io/latest


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

This will make the version list be automated based on Github API data treated in https://get.dgraph.io/latest