### PR TITLE
docs(GraphQL): Add paragraph around combining ID with @id

### DIFF
--- a/content/graphql/schema/ids.md
+++ b/content/graphql/schema/ids.md
@@ -23,7 +23,7 @@ type Post {
 }
 ```
 
-In a single page app, you'll want to render the page for `http://.../posts/0x123` when a user clicks to view the post with id `0x123`.  You app can then use a `getPost(id: "0x123") { ... }` GraphQL query to fetch the data to generate the page.
+In a single page app, you'll want to render the page for `http://.../posts/0x123` when a user clicks to view the post with id `0x123`.  Your app can then use a `getPost(id: "0x123") { ... }` GraphQL query to fetch the data to generate the page.
 
 For input and output, `ID`s are treated as strings.
 
@@ -50,7 +50,27 @@ Identities created with `@id` are reusable - if you delete an existing user, you
 
 Fields with the `@id` directive must have the type `String!`.
 
-As with `ID` types, Dgraph will generate queries and mutations so you'll also be able to query, update and delete by id.
+As with `ID` types, Dgraph will generate queries and mutations so you'll also be able to query, update and delete by the field with the @id directive.
+
+In a single page app, you'll want to render the page for `http://.../user/foobar` when a user clicks to view author bio page for user `foobar`.  Your app can then use a `getUser(username: "foobar") { ... }` GraphQL query to fetch the data to generate the page.
+
+### Combining ID and @id directive
+
+You may use both the ID scalar and the @id directive on another field definition to have both a unique identifier and a generated id.
+
+For example, you might set the following type in a schema.
+
+```graphql
+type User {
+    id: ID!
+    username: String! @id
+    ...
+}
+```
+
+Dgraph will still require a unique username when creating a new user. This schema provides the benefits of both of the previous examples above. Your app can then use the `getUser(...) { ... }` query providing either the id or the username.
+
+When your app needs to reference a specific `User` for reference by edge in another mutation, it may then use either the `id` or the `username` field.
 
 ### More to come
 

--- a/content/graphql/schema/ids.md
+++ b/content/graphql/schema/ids.md
@@ -13,7 +13,7 @@ There are two types of identifiers built into Dgraph: the `ID` scalar type and t
 
 ### The `ID` type
 
-In Dgraph, every node has a unique 64-bit identifier that you can expose in GraphQL using the `ID` type. `ID`s are auto-generated, immutable and never reused. Each type can have at most one `ID` field.
+In Dgraph, every node has a unique 64-bit identifier that you can expose in GraphQL using the `ID` type. An `ID` is auto-generated, immutable and never reused. Each type can have at most one `ID` field.
 
 The `ID` type works great when you need to use an identifier on nodes and don't need to set that identifier externally (for example, posts and comments).
 
@@ -26,7 +26,7 @@ type Post {
 }
 ```
 
-In a single-page app, you should the page for `http://.../posts/0x123` when a user clicks to view the post with `ID` 0x123.  Your app can then use a `getPost(id: "0x123") { ... }` GraphQL query to fetch the data used to generate the page.
+In a single-page app, you could generate the page for `http://.../posts/0x123` when a user clicks to view the post with `ID` 0x123. Your app can then use a `getPost(id: "0x123") { ... }` GraphQL query to fetch the data used to generate the page.
 
 For input and output, `ID`s are treated as strings.
 
@@ -36,7 +36,7 @@ You can also update and delete posts by `ID`.
 
 For some types, you'll need a unique identifier set from outside Dgraph.  A common example is a username.
 
-The `@id` directive tells Dgraph to keep values of that field unique and to use them as identifiers.
+The `@id` directive tells Dgraph to keep that field's values unique and use them as identifiers.
 
 For example, you might set the following type in a schema:
 
@@ -55,13 +55,13 @@ Fields with the `@id` directive must have the type `String!`.
 
 As with `ID` types, Dgraph generates queries and mutations so you can query, update and delete data in fields specified with the `@id` directive.
 
-In a single-page app, you should render the page for `http://.../user/foobar` when a user clicks to view the author bio page for user `foobar`. Your app can then use a `getUser(username: "foobar") { ... }` GraphQL query to fetch the data and generate the page.
+In a single-page app, you could render the page for `http://.../user/Erik` when a user clicks to view the author bio page for that user. Your app can then use a `getUser(username: "Erik") { ... }` GraphQL query to fetch the data and generate the page.
 
 ### Combining `ID` and `@id`
 
-You may use both the `ID` type and the `@id` directive on another field definition to have both a unique identifier and a generated identifier.
+You can use both the `ID` type and the `@id` directive on another field definition to have both a unique identifier and a generated identifier.
 
-For example, you might set the following type in a schema:
+For example, you might define the following type in a schema:
 
 ```graphql
 type User {
@@ -71,7 +71,7 @@ type User {
 }
 ```
 
-With this schema, Dgraph will require a unique username when creating a new user. This schema provides the benefits of both of the previous examples above. Your app can then use the `getUser(...) { ... }` query to provide either the Dgraph-generated `id` or the externally-generated `username`.
+With this schema, Dgraph requires a unique `username` when creating a new user. This schema provides the benefits of both of the previous examples above. Your app can then use the `getUser(...) { ... }` query to provide either the Dgraph-generated `id` or the externally-generated `username`.
 <!--
 ### More to come
 

--- a/content/graphql/schema/ids.md
+++ b/content/graphql/schema/ids.md
@@ -6,12 +6,12 @@ weight = 3
     parent = "schema"
 +++
 
-There are two types of identity built into Dgraph, implemented as the `ID` scalar type and the `@id` directive.
+There are two types of identifiers built into Dgraph: the `ID` scalar type and the `@id` directive.
 
 * The `ID` scalar type is used when you don't need to set an identifier outside of Dgraph.
 * The `@id` directive is used for external identifiers, such as email addresses.
 
-### The ID type
+### The `ID` type
 
 In Dgraph, every node has a unique 64-bit identifier that you can expose in GraphQL using the `ID` type. `ID`s are auto-generated, immutable and never reused. Each type can have at most one `ID` field.
 
@@ -32,7 +32,7 @@ For input and output, `ID`s are treated as strings.
 
 You can also update and delete posts by `ID`.
 
-### The @id directive
+### The `@id` directive
 
 For some types, you'll need a unique identifier set from outside Dgraph.  A common example is a username.
 

--- a/content/graphql/schema/ids.md
+++ b/content/graphql/schema/ids.md
@@ -6,15 +6,18 @@ weight = 3
     parent = "schema"
 +++
 
-There are two types of identity built into Dgraph. Those are accessed using the `ID` scalar type and the `@id` directive.
+There are two types of identity built into Dgraph, implemented as the `ID` scalar type and the `@id` directive.
+
+* The `ID` scalar type is used when you don't need to set an identifier outside of Dgraph.
+* The `@id` directive is used for external identifiers, such as email addresses.
 
 ### The ID type
 
 In Dgraph, every node has a unique 64-bit identifier that you can expose in GraphQL using the `ID` type. `ID`s are auto-generated, immutable and never reused. Each type can have at most one `ID` field.
 
-The `ID` type works great for things that you'll want to refer to via an id, but don't need to set the identifier externally.  Examples are things like posts, comments, tweets, etc. 
+The `ID` type works great when you need to use an identifier on nodes and don't need to set that identifier externally (for example, posts and comments).
 
-For example, you might set the following type in a schema.
+For example, you might set the following type in a schema:
 
 ```graphql
 type Post {
@@ -23,11 +26,11 @@ type Post {
 }
 ```
 
-In a single page app, you'll want to render the page for `http://.../posts/0x123` when a user clicks to view the post with id `0x123`.  Your app can then use a `getPost(id: "0x123") { ... }` GraphQL query to fetch the data to generate the page.
+In a single-page app, you should the page for `http://.../posts/0x123` when a user clicks to view the post with `ID` 0x123.  Your app can then use a `getPost(id: "0x123") { ... }` GraphQL query to fetch the data used to generate the page.
 
 For input and output, `ID`s are treated as strings.
 
-You'll also be able to update and delete posts by id.
+You can also update and delete posts by `ID`.
 
 ### The @id directive
 
@@ -35,7 +38,7 @@ For some types, you'll need a unique identifier set from outside Dgraph.  A comm
 
 The `@id` directive tells Dgraph to keep values of that field unique and to use them as identifiers.
 
-For example, you might set the following type in a schema.
+For example, you might set the following type in a schema:
 
 ```graphql
 type User {
@@ -44,21 +47,21 @@ type User {
 }
 ```
 
-Dgraph will then require a unique username when creating a new user --- it'll generate the input type for `addUser` with `username: String!` so you can't make an add mutation without setting a username, and when processing the mutation, Dgraph will ensure that the username isn't already set for another node of the `User` type.
+Dgraph requires a unique username when creating a new user. It generates the input type for `addUser` with `username: String!`, so you can't make an add mutation without setting a username; and when processing the mutation, Dgraph will ensure that the username isn't already set for another node of the `User` type.
 
-Identities created with `@id` are reusable - if you delete an existing user, you can reuse the username.
+Identities created with `@id` are reusable. If you delete an existing user, you can reuse the username.
 
 Fields with the `@id` directive must have the type `String!`.
 
-As with `ID` types, Dgraph will generate queries and mutations so you'll also be able to query, update and delete by the field with the @id directive.
+As with `ID` types, Dgraph generates queries and mutations so you can query, update and delete data in fields specified with the `@id` directive.
 
-In a single page app, you'll want to render the page for `http://.../user/foobar` when a user clicks to view author bio page for user `foobar`.  Your app can then use a `getUser(username: "foobar") { ... }` GraphQL query to fetch the data to generate the page.
+In a single-page app, you should render the page for `http://.../user/foobar` when a user clicks to view the author bio page for user `foobar`. Your app can then use a `getUser(username: "foobar") { ... }` GraphQL query to fetch the data and generate the page.
 
-### Combining ID and @id directive
+### Combining `ID` and `@id`
 
-You may use both the ID scalar and the @id directive on another field definition to have both a unique identifier and a generated id.
+You may use both the `ID` type and the `@id` directive on another field definition to have both a unique identifier and a generated identifier.
 
-For example, you might set the following type in a schema.
+For example, you might set the following type in a schema:
 
 ```graphql
 type User {
@@ -68,12 +71,11 @@ type User {
 }
 ```
 
-Dgraph will still require a unique username when creating a new user. This schema provides the benefits of both of the previous examples above. Your app can then use the `getUser(...) { ... }` query providing either the id or the username.
-
-When your app needs to reference a specific `User` for reference by edge in another mutation, it may then use either the `id` or the `username` field.
-
+With this schema, Dgraph will require a unique username when creating a new user. This schema provides the benefits of both of the previous examples above. Your app can then use the `getUser(...) { ... }` query to provide either the Dgraph-generated `id` or the externally-generated `username`.
+<!--
 ### More to come
 
 We are currently considering allowing types other than `String` with `@id`, see [here](https://discuss.dgraph.io/t/id-with-type-int/10402)
 
 We are currently considering expanding uniqueness to include composite ids and multiple unique fields (e.g. [this](https://discuss.dgraph.io/t/support-multiple-unique-fields-in-dgraph-graphql/8512) issue).
+-->

--- a/content/graphql/schema/ids.md
+++ b/content/graphql/schema/ids.md
@@ -1,12 +1,12 @@
 +++
 title = "IDs"
-description = "There are two types of identity built into Dgraph. Those are accessed using the ID scalar type and the @id directive."
+description = "Dgraph database provides two types of identifiers: the ID scalar type and the @id directive."
 weight = 3
 [menu.main]
     parent = "schema"
 +++
 
-There are two types of identifiers built into Dgraph: the `ID` scalar type and the `@id` directive.
+Dgraph provides two types of built-in identifiers: the `ID` scalar type and the `@id` directive.
 
 * The `ID` scalar type is used when you don't need to set an identifier outside of Dgraph.
 * The `@id` directive is used for external identifiers, such as email addresses.


### PR DESCRIPTION
- Add information on relationship between ID and @id
- Add example of get query when using `@id` directive
- Typo fixes
- Rephrased a sentence that was using `id` in the @id directive paragraph.
@aaroncarey patched commits 2-5 to edit the full page for TW style, improve the introduction, and move a forward-looking statement to the comments.

Fixes DOC-115

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
