### PR TITLE
Docs(Other): Fix broken link for @secret

### DIFF
--- a/content/graphql/authorization/directive.md
+++ b/content/graphql/authorization/directive.md
@@ -6,7 +6,7 @@ weight = 2
     parent = "authorization"
 +++
 
-Given an authentication mechanism and a signed JSON Web Token (JWT), the `@auth` directive tells Dgraph how to apply authorization.  The directive can be used on any type except `union` (that isn't a `@remote` type) and specifies the authorization for `query` as well as the `add`, `update`, and `delete` mutations. Additionally, this directive can also be used with the [`@secret`](/graphql/schema/types.md#password-type) directive. If you specify a `password` auth rule, Dgraph will use it to authorize the `check<Type>Password` query.
+Given an authentication mechanism and a signed JSON Web Token (JWT), the `@auth` directive tells Dgraph how to apply authorization.  The directive can be used on any type except `union` (that isn't a `@remote` type) and specifies the authorization for `query` as well as the `add`, `update`, and `delete` mutations. Additionally, this directive can also be used with the [`@secret`](/graphql/schema/types#password-type) directive. If you specify a `password` auth rule, Dgraph will use it to authorize the `check<Type>Password` query.
 
 {{% notice "note" %}}
 The [Union type](/graphql/schema/types#union-type) does not support the `@auth` directive 


### PR DESCRIPTION
Fixes the broken link to the `@secret` directive reference [here](https://dgraph.io/docs/graphql/authorization/directive/).

Cherry-pick to 20.11 and 20.07
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->

