### PR TITLE
docs(graphql): Document ClosedByDefault setting for authorization.

### DIFF
--- a/content/graphql/authorization/authorization-overview.md
+++ b/content/graphql/authorization/authorization-overview.md
@@ -34,7 +34,7 @@ To define the connection method, you must set the `# Dgraph.Authorization` objec
 * `VerificationKey` is the string value of the key (newlines replaced with `\n`) wrapped in `""`
 * `JWKURL` is the URL for the JSON Web Key sets
 * `Audience` is used to verify the `aud` field of a JWT which might be set by certain providers. It indicates the intended audience for the JWT. When doing authentication with `JWKURL`, this field is mandatory as Identity Providers share JWKs among multiple tenants
-* `ClosedByDefault`, if set to `true`, requires auth for all requests even if the type does not specify the [`@auth`]({{< relref "directive.md" >}}) directive. If omitted, the default setting is `false`.
+* `ClosedByDefault`, if set to `true`, requires authorization for all requests even if the type does not specify the [`@auth`]({{< relref "directive.md" >}}) directive. If omitted, the default setting is `false`.
 
 To set up the authentication connection method:
 

--- a/content/graphql/authorization/authorization-overview.md
+++ b/content/graphql/authorization/authorization-overview.md
@@ -22,10 +22,10 @@ The connection between Dgraph and your authentication mechanism can be a JSON We
 
 #### `Dgraph.Authorization` parameters
 
-To define the connection method, you must set the `#Dgraph.Authorization` object:
+To define the connection method, you must set the `# Dgraph.Authorization` object:
 
 ```json
-{"Header":"", "Namespace":"", "Algo":"", "VerificationKey":"", "JWKURL":"", "Audience":[]}
+{"Header":"", "Namespace":"", "Algo":"", "VerificationKey":"", "JWKURL":"", "Audience":[], "ClosedByDefault": false}
 ```
 
 * `Header` is the header in which requests will send the signed JWT
@@ -34,6 +34,7 @@ To define the connection method, you must set the `#Dgraph.Authorization` object
 * `VerificationKey` is the string value of the key (newlines replaced with `\n`) wrapped in `""`
 * `JWKURL` is the URL for the JSON Web Key sets
 * `Audience` is used to verify the `aud` field of a JWT which might be set by certain providers. It indicates the intended audience for the JWT. When doing authentication with `JWKURL`, this field is mandatory as Identity Providers share JWKs among multiple tenants
+* `ClosedByDefault`, if set to `true`, requires auth for all requests even if the type does not specify the [`@auth`]({{< relref "directive.md" >}}) directive. If omitted, the default setting is `false`.
 
 To set up the authentication connection method:
 


### PR DESCRIPTION
This documents the ClosedByDefault setting in the Dgraph.Authorization
object. This was introduced in Dgraph v20.11.0 in dgraph-io/dgraph#6779.

Fixes DOC-134

Related:
https://discuss.dgraph.io/t/implemented-queries-closed-by-default/12626


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
