### PR TITLE
Docs(GraphQL) add list coercion documentation and example.

### DIFF
--- a/content/graphql/queries/and-or-not.md
+++ b/content/graphql/queries/and-or-not.md
@@ -53,9 +53,9 @@ queryPost(filter: {
   } ) { ... }
 ```
 
-The `and` and `or` filter accept a list of filters. Any non list filter will be coeorced into a list. This provides backwards compatibility while allowing for more complex filters.
+The `and` and `or` filter both accept a list of filters. Per the GraphQL specification, non-list filters are coerced into a list. This provides backwards compatibility while allowing for more complex filters.
 
-Example: Posts that have `GraphQL` in the title and not the tag `GraphQL`, or have `Dgraph` in the title and not the tag `Dgraph`
+Example: Query for posts that have `GraphQL` in the title but that lack the `GraphQL` tag, or that have `Dgraph` in the title but lack the `Dgraph` tag.
 
 ```graphql
 queryPost(filter: {

--- a/content/graphql/queries/and-or-not.md
+++ b/content/graphql/queries/and-or-not.md
@@ -55,7 +55,7 @@ queryPost(filter: {
 
 The `and` and `or` filter accept a list of filters. Any non list filter will be coeorced into a list. This provides backwards compatibility while allowing for more complex filters.
 
-Example: Posts that have "GraphQL" in the title and not the tag "GraphQL", or have "Dgraph" in the title and not the tag "Dgraph"
+Example: Posts that have `GraphQL` in the title and not the tag `GraphQL`, or have `Dgraph` in the title and not the tag `Dgraph`
 
 ```graphql
 queryPost(filter: {

--- a/content/graphql/queries/and-or-not.md
+++ b/content/graphql/queries/and-or-not.md
@@ -49,6 +49,19 @@ Example: Posts that have "GraphQL" in the title, or have the tag "GraphQL" and m
 ```graphql
 queryPost(filter: {
     title: { allofterms: "GraphQL"},
-    or: { title: { allofterms: "Dgraph" }, tags: { eg: "GraphQL" } }
+    or: { title: { allofterms: "Dgraph" }, tags: { eq: "GraphQL" } }
+  } ) { ... }
+```
+
+The `and` and `or` filter accept a list of filters. Any non list filter will be coeorced into a list. This provides backwards compatibility while allowing for more complex filters.
+
+Example: Posts that have "GraphQL" in the title and not the tag "GraphQL", or have "Dgraph" in the title and not the tag "Dgraph"
+
+```graphql
+queryPost(filter: {
+    or: [
+      and: [{ title: { allofterms: "GraphQL" } }, { not: { tags: { eq: "GraphQL" } } }]
+      and: [{ title: { allofterms: "Dgraph" } }, { not: { tags: { eq: "Dgraph" } } }]
+    ]
   } ) { ... }
 ```


### PR DESCRIPTION
Also fixed a typo from `eg` to `eq` that caught my eye.

This change was implemented in 20.11 to coerce types into lists and specifically allow the `and` and `or` filter to be a list of filters. It was not clearly stated in the changelog, but can be found in these discuss posts:

https://discuss.dgraph.io/t/there-can-be-only-one-input-field-named/8384/9
https://discuss.dgraph.io/t/limitations-of-graphql-nested-filters/10798