### PR TITLE
Other: updated client reference to javascript bad link broke hugo

### DIFF
--- a/content/clients/_index.md
+++ b/content/clients/_index.md
@@ -52,7 +52,7 @@ weight = 7
   </div>
   <div class="item">
     <div class="icon"><i class="lni lni-javascript" aria-hidden="true"></i></div>
-    <a href="{{< relref "javascript.md">}}">
+    <a href="{{< relref "javascript/_index.md">}}">
       <h2>JavaScript</h2>
       <p>
         Dgraph JavaScript client


### PR DESCRIPTION
Fixed issue where hugo server would not start due to missing link.

```
ERROR 2021/02/12 17:30:27 [en] REF_NOT_FOUND: Ref "javascript.md": "/Users/joaquin/workarea/dgraph-docs/content/clients/_index.md:55:14": page not found
```