### PR TITLE
Docs(GraphQL) add Slash grpc connection method and example.

### DIFF
--- a/content/clients/javascript/grpc.md
+++ b/content/clients/javascript/grpc.md
@@ -62,7 +62,7 @@ const dgraphClient = new dgraph.DgraphClient(clientStub);
 
 #### Connecting to Slash
 
-Alternatively to the above, Slash users can create `DgraphClientStub` by using the specialized method for Slash.
+Alternatively to the above, Slash users can create a `DgraphClientStub` by using the specialized method for Slash.
 
 ````js
 const dgraph = require("dgraph-js");

--- a/content/clients/javascript/grpc.md
+++ b/content/clients/javascript/grpc.md
@@ -60,6 +60,24 @@ const clientStub = new dgraph.DgraphClientStub(
 const dgraphClient = new dgraph.DgraphClient(clientStub);
 ```
 
+#### Connecting to Slash
+
+Alternatively to the above, Slash users can create `DgraphClientStub` by using the specialized method for Slash.
+
+````js
+const dgraph = require("dgraph-js");
+const grpc = require("grpc");
+
+const clientStub = new dgraph.clientStubFromSlashGraphQLEndpoint(
+  "https://frozen-mango.cloud.dgraph.io/graphql",
+  "Your Slash Client API Key Here"
+)
+const dgraphClient = new dgraph.DgraphClient(clientStub);
+````
+
+Replace the GraphQL endpoint with the one obtained from your Slash admin Overview page,
+and create an Client API Key from your Slash admin Settings page.
+
 To facilitate debugging, [debug mode](#debug-mode) can be enabled for a client.
 
 ### Altering the Database


### PR DESCRIPTION
This was changed in the client by PR: https://github.com/dgraph-io/dgraph-js/commit/18bc38f6eac782386bfda4c90893a36be586311b#diff-009952dc4ac10bec7174ab1e2024ac38bb7adbc0eb1dbd2050a8c789466933ba

This was discussed in topic: https://discuss.dgraph.io/t/working-grpc-example-with-slash-graphql/9628/9
