### PR TITLE
Docs(Deploy): updated deploy / administration / exports section

### DIFF
--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -263,7 +263,7 @@ mutation {
 ```
 
 {{% notice "note" %}}
-Dgraph URL used for s3 is different than AWS CLI tools with the `aws s3` command, which uses a shortened format: `s3://<bucket-name>`.
+Dgraph URL used for S3 is different than AWS CLI tools with the `aws s3` command, which uses a shortened format: `s3://<bucket-name>`.
 {{% /notice %}}
 
 

--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -284,7 +284,7 @@ mutation {
 }
 ```
 
-#### Exporting to a Minio Gateway
+#### Exporting to a MinIO Gateway
 
 MinIO can be used as a gateway to other object stores, such as [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) or [Google Cloud Storage](https://cloud.google.com/storage).  You can use the above MinIO GraphQL mutation with MinIO configured as a gateway.
 
@@ -352,7 +352,7 @@ Once you have a `credentials.json`, you can access GCS locally using one of thes
      enabled: true
      projectId: <project-id>
      gcsKeyJson: |
-     $(cat "</path/to/credentials.json>")
+       $(cat "</path/to/credentials.json>")
    EOF
 
    ## deploy MinIO GCS Gateway

--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -408,7 +408,7 @@ The `encryption-key-file` was used for `encryption-at-rest` and will now also be
 
 ### Using `curl` to trigger an export
 
-This is an example in how you can use `curl` to tigger an export.
+This is an example of how you can use `curl` to trigger an export.
 
   1. Create GraphQL file for the desired mutation:
      ```bash

--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -310,7 +310,7 @@ Once you have the `AccountName` and `AccountKey`, you can access Azure Blob Stor
     --env MINIO_SECRET_KEY="<AccountKey>" \
     minio/minio gateway azure
    ```
- * Using [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html) with the MinIO Helm chart for Kubernetes:
+ * Using [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html) with the [MinIO Helm chart](https://github.com/minio/charts) for Kubernetes:
    ```bash
    helm repo add minio https://helm.min.io/
    helm install my-gateway minio/minio \
@@ -341,7 +341,7 @@ Once you have a `credentials.json`, you can access GCS locally using one of thes
      --env MINIO_SECRET_KEY="<minio-secret-key>" \
      minio/minio gateway gcs "<project-id>"
    ```
-*  Using [MinIO GCS Gateway](https://docs.min.io/docs/minio-gateway-for-gcs.html) with the MinIO Helm chart for Kubernetes:
+*  Using [MinIO GCS Gateway](https://docs.min.io/docs/minio-gateway-for-gcs.html) with the [MinIO Helm chart](https://github.com/minio/charts) for Kubernetes:
    ```bash
    ## create MinIO Helm config
    cat <<-EOF > myvalues.yaml
@@ -352,7 +352,7 @@ Once you have a `credentials.json`, you can access GCS locally using one of thes
      enabled: true
      projectId: <project-id>
      gcsKeyJson: |
-       $(cat "</path/to/credentials.json>")
+   $(IFS='\n'; while read -r LINE; do printf '    %s\n' "$LINE"; done < "</path/to/credentials.json>")
    EOF
 
    ## deploy MinIO GCS Gateway

--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -109,7 +109,7 @@ dgraph alpha --mutations strict
 Clients can use alter operations to apply schema updates and drop particular or all predicates from the database.
 By default, all clients are allowed to perform alter operations.
 You can configure Dgraph to only allow alter operations when the client provides a specific token.
-This "Simple ACL" token can be used to prevent clients from making unintended or accidental schema updates or predicate drops.
+You can use this "Simple ACL" token to prevent clients from making unintended or accidental schema updates or predicate drops.
 
 You can specify the auth token with the `--auth_token` option for each Dgraph Alpha in the cluster.
 Clients must include the same auth token to make alter requests.
@@ -167,13 +167,13 @@ cluster. Dgraph does not copy all files to the Alpha that initiated the export.
 The user must also ensure that there is sufficient space on disk to store the
 export.
 
-### Configuring Dgraph Alpha server
+### Configuring Dgraph Alpha server nodes
 
 Each Dgraph Alpha leader for a group writes output as a gzipped file to the export
 directory specified via the `--export` flag (defaults to a directory called `"export"`). If any of the groups fail, the
 entire export process is considered failed and an error is returned.
 
-As an example of configuring `export`, you can run this:
+For example, you could run the following commands to configure data exports:
 
 ```bash
 docker run --detach --rm --name dgraph-standalone \
@@ -186,7 +186,7 @@ docker run --detach --rm --name dgraph-standalone \
 
 ### Export data format
 
-The data is exported in RDF format by default.  You can explicitly set the output format with the `format` field. For example:
+By default, Dgraph exports data in RDF format. You can explicitly set the output format with the `format` field. For example:
 
 ```graphql
 mutation {
@@ -200,7 +200,7 @@ mutation {
 ```
 
 
-A different output format may be specified with the `format` field. For example:
+You can specify a different output format using the `format` field. For example:
 
 ```graphql
 mutation {
@@ -221,7 +221,7 @@ Currently, `rdf` and `json` are the only formats supported.
 This feature was introduced in [v20.11.0](https://github.com/dgraph-io/dgraph/releases/tag/v20.11.0).
 {{% /notice %}}
 
-You can override the default folder path by adding `destination` input field to the directory where you want to export data in the GraphQL mutation request as follows:
+You can override the default folder path by adding the `destination` input field to the directory where you want to export data in the GraphQL mutation request, as follows:
 
 ```graphql
 mutation {
@@ -286,11 +286,11 @@ mutation {
 
 #### Exporting to a MinIO Gateway
 
-MinIO can be used as a gateway to other object stores, such as [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) or [Google Cloud Storage](https://cloud.google.com/storage).  You can use the above MinIO GraphQL mutation with MinIO configured as a gateway.
+You can use MinIO as a gateway to other object stores, such as [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) or [Google Cloud Storage](https://cloud.google.com/storage).  You can use the above MinIO GraphQL mutation with MinIO configured as a gateway.
 
 ##### Azure Blob Storage
 
-You can use [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) through the [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html).  You need to configure a [storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) and a Blob [container](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction#containers) to organize the blobs.  The blob container name synonymous to bucket name when specifying the destination.  
+You can use [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) through the [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html).  You need to configure a [storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) and a Blob [container](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction#containers) to organize the blobs. The name of the blob container should be the same as the name of the storage bucket you use when specifying the destination.
 
 For MinIO configuration, you will need to [retrieve storage accounts keys](https://docs.microsoft.com/azure/storage/common/storage-account-keys-manage). The [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html) will use `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` to correspond to Azure Storage Account `AccountName` and `AccountKey`.
 

--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -406,7 +406,7 @@ Export is available wherever an Alpha is running. To encrypt an export, the Alph
 The `encryption-key-file` was used for `encryption-at-rest` and will now also be used for encrypted backups and exports.
 {{% /notice %}}
 
-### Using curl to trigger an export
+### Using `curl` to trigger an export
 
 This is an example in how you can use `curl` to tigger an export.
 
@@ -427,7 +427,7 @@ This is an example in how you can use `curl` to tigger an export.
      }
      EOF
      ```
-  2. Trigger an export with curl
+  2. Trigger an export with `curl`
      ```bash
      curl http://localhost:8080/admin --silent --request POST \
        --header "Content-Type: application/graphql" \

--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -173,7 +173,7 @@ Each Dgraph Alpha leader for a group writes output as a gzipped file to the expo
 directory specified via the `--export` flag (defaults to a directory called `"export"`). If any of the groups fail, the
 entire export process is considered failed and an error is returned.
 
-For example, you could run the following commands to configure data exports:
+As an example of configuring `export`, you can run this:
 
 ```bash
 docker run --detach --rm --name dgraph-standalone \
@@ -183,6 +183,10 @@ docker run --detach --rm --name dgraph-standalone \
   --env "DGRAPH_ALPHA_EXPORT=/dgraph/myexports" \
   dgraph/standalone:{{< version >}}
 ```
+
+{{% notice "tip" %}}
+The `export` configuration can be configured as an environment variable `DGRAPH_ALPHA_EXPORT`, command line flag `--export`, or in a configuration file with the `export` key.  See [Config]({{< relref "config" >}}) for more information in general about configuring Dgraph.
+{{% /notice %}}
 
 ### Export data format
 
@@ -263,7 +267,7 @@ mutation {
 ```
 
 {{% notice "note" %}}
-Dgraph URL used for S3 is different than AWS CLI tools with the `aws s3` command, which uses a shortened format: `s3://<bucket-name>`.
+The Dgraph URL used for S3 is different than the AWS CLI tools with the `aws s3` command, which uses a shortened format: `s3://<bucket-name>`.
 {{% /notice %}}
 
 
@@ -290,7 +294,7 @@ You can use MinIO as a gateway to other object stores, such as [Azure Blob Stora
 
 ##### Azure Blob Storage
 
-You can use [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) through the [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html).  You need to configure a [storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) and a Blob [container](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction#containers) to organize the blobs. The name of the blob container should be the same as the name of the storage bucket you use when specifying the destination.
+You can use [Azure Blob Storage](https://azure.microsoft.com/services/storage/blobs/) through the [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html).  You need to configure a [storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) and a Blob [container](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction#containers) to organize the blobs. The name of the blob container is what you use for `<bucket-name>` when specifying the `destination` in the GraphQL mutation.
 
 For MinIO configuration, you will need to [retrieve storage accounts keys](https://docs.microsoft.com/azure/storage/common/storage-account-keys-manage). The [MinIO Azure Gateway](https://docs.min.io/docs/minio-gateway-for-azure.html) will use `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` to correspond to Azure Storage Account `AccountName` and `AccountKey`.
 
@@ -400,10 +404,10 @@ mutation {
 
 ### Encrypting exports
 
-Export is available wherever an Alpha is running. To encrypt an export, the Alpha must be configured with the `encryption-key-file`.
+Export is available wherever an Alpha is running. To encrypt an export, the Alpha must be configured with the `encryption_key_file`.
 
 {{% notice "note" %}}
-The `encryption-key-file` was used for `encryption-at-rest` and will now also be used for encrypted backups and exports.
+The `encryption_key_file` was used for [Encryption at Rest]({{< relref "enterprise-features/encryption-at-rest" >}}) and will now also be used for encrypted exports.
 {{% /notice %}}
 
 ### Using `curl` to trigger an export


### PR DESCRIPTION
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->

The primary purpose of this PR is to update new features, e.g. object storage, that are not yet documented for Dgraph Alpha export functionality.  The secondary purpose is to clean up the organization and give users a comprehension guide to use Dgraph Alpha export.

This PR adds the following:

* added section on object storage
* added section to use MinIO gateway to Azure storage blob and Google Cloud Storage
* added section to use curl command with GraphQL
* added section for anonymous 
* added section on how to turn off default HTTPS
* updated using `destination` for file paths, and put this under its own section.
* updated content on configuration Dgraph Alpha server configuration for `--exports` and placed this in its own identifiable section.
   * added an example of how to run Dgraph with this export setting
 * added an example of how to trigger an export with `curl`

These have been throughly tested with local file path, S3 bucket, and MinIO gateway bucket with Azure Blob and GCS using docker for MinIO and Dgraph.  What was not tested was using the MinIO command line or testing with Kubernetes. The Helm chart configuration is based on previous configuration and testing used with Dgraph binary backups functionality.
