### PR TITLE
[Cherry-Pick master -> release/v20.07]: Docs(Migration): "Migrate from Dgraph v1.0 to Newer Versions" #7179

### DIFF
--- a/content/howto/migrate-dgraph-1-1.md
+++ b/content/howto/migrate-dgraph-1-1.md
@@ -1,32 +1,47 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
-title = "Migrate to Dgraph v1.1"
+title = "Migrate from Dgraph v1.0"
 weight = 11
 [menu.main]
     parent = "howto"
 +++
 
+This document summarizes major changes in Dgraph database that you should be
+aware of as you migrate your data and client applications from Dgraph v1.0 to
+newer Dgraph versions.
+
 ## Schema types: scalar `uid` and list `[uid]`
 
-The semantics of predicates of type `uid` has changed in Dgraph 1.1. Whereas before all `uid` predicates implied a one-to-many relationship, now a one-to-one relationship or a one-to-many relationship can be expressed.
+The semantics of predicates of type `uid` has changed since Dgraph v1.0. 
+In Dgraph v1.0 all `uid` predicates implied a one-to-many relationship, but now
+you can express a one-to-one relationship or a one-to-many relationship. The
+following syntax example demonstrates both types of relationships:
 
-```
+```text
 friend: [uid] .
 best_friend: uid .
 ```
 
-In the above, the predicate `friend` allows a one-to-many relationship (i.e a person can have more than one friend) and the predicate best_friend can be at most a one-to-one relationship.
+In the above example, the predicate `friend` allows a one-to-many relationship
+(i.e a person can have more than one friend) and the predicate `best_friend` 
+allows a one-to-one relationship.
 
-This syntactic meaning is consistent with the other types, e.g., `string` indicating a single-value string and `[string]` representing many strings. This change makes the `uid` type work similarly to other types.
+The new `uid` syntax is consistent with that used for other types. For example,
+`string` indicates a  single-value string and `[string]` represents many strings.
 
-To migrate existing schemas from Dgraph v1.0 to Dgraph v1.1, update the schema file from an export so all predicates of type `uid` are changed to `[uid]`. Then use the updated schema when loading data into Dgraph v1.1. For example, for the following schema:
+To migrate existing schemas from Dgraph v1.0 to newer Dgraph versions, update
+the schema file from an export so all predicates of type `uid` are changed to
+`[uid]`. Then, use the updated schema when loading data into Dgraph {{< version >}}. 
+
+For example, you could start with the following schema in Dgraph v1.0:
 
 ```text
 name: string .
 friend: uid .
 ```
 
-becomes
+When exported, you get the following schema, suitable for migration into newer
+Dgraph versions:
 
 ```text
 name: string .
@@ -34,15 +49,18 @@ friend: [uid] .
 ```
 ## Type system
 
-The new [type system]({{< relref "query-language/type-system.md" >}}) introduced in Dgraph 1.1 should not affect migrating data from a previous version. However, a couple of features in the query language will not work as they did before: `expand()` and `_predicate_`.
+The new [type system]({{< relref "query-language/type-system.md" >}}) introduced
+starting in Dgraph 1.1 should not affect migrating data from a previous version.
+However, two features of the query language no longer work as they did
+in Dgraph v1.0: `expand()` and `_predicate_`.
 
-The reason is that the internal predicate that associated each node with its predicates (called `_predicate_`) has been removed. Instead, to get the predicates that belong to a node, the type system is used.
+### Changes to the `expand()` function
 
-### `expand()`
+Expand queries will not work until the type system has been properly set up. For
+example, the following query will return an empty result in newer Dgraph
+versions if the node `0xff` has no type information.
 
-Expand queries will not work until the type system has been properly set up. For example, the following query will return an empty result in Dgraph 1.1 if the node 0xff has no type information.
-
-```text
+```graphql
 {
   me(func: uid(0xff)) {
     expand(_all_)
@@ -50,38 +68,59 @@ Expand queries will not work until the type system has been properly set up. For
 }
 ```
 
-To make it work again, add a type definition via the alter endpoint. Let’s assume the node in the previous example represents a person. Then, the basic Person type could be defined as follows:
+To make this query work in newer Dgraph versions, you need to add a type
+definition to the schema, and then associate a node with that type using a
+mutation.
 
-```text
+You can add a type definition using the `/alter` endpoint. Let's assume that
+the node shown in the previous example represents a person, with the `Person`
+type defined as follows:
+
+```graphql
 type Person {
   name
   age
 }
 ```
 
-After that, the node is associated with the type by adding the following RDF triple to Dgraph (using a mutation):
+Next, associate a node with the `Person` type by adding the following RDF 
+triple to Dgraph (using a mutation):
 
 ```text
 <0xff> <dgraph.type> "Person" .
 ```
 
-After that, the results of the query in both Dgraph v1.0 and Dgraph v1.1 should be the same.
+With these two steps complete, the results of the query in both Dgraph v1.0 and
+newer Dgraph versions should be the same.
 
 ### `_predicate_`
 
-The other consequence of removing `_predicate_` is that it cannot be referenced explicitly in queries. In Dgraph 1.0, the following query returns the predicates of the node 0xff.
+In Dgraph v1.0 an "internal predicate" (called `_predicate_`) was used to
+associate each node with its predicates. This "internal predicate" has been
+removed from newer Dgraph versions; instead, you use the type system to get the
+predicates that belong to nodes of a given type.
 
-```ql
+Because `_predicate_` isn't supported in newer Dgraph versions, you can't
+reference it explicitly in queries as you could in Dgraph v1.0. 
+
+For example, the following query returns the predicates of the node `0xff` in
+Dgraph v1.0:
+
+```graphql
 {
   me(func: uid(0xff)) {
-     _predicate_ # NOT available in Dgraph v1.1
+     _predicate_ # NOT available in Dgraph v1.1 and newer versions
   }
 }
 ```
 
-**There’s no exact equivalent of this behavior in Dgraph 1.1**, but the information can be queried by first querying for the types associated with that node with the query
+In newer Dgraph versions, there isn't an equivalent to this query. Instead, you
+can use the type system to fetch the predicates for a given node.
 
-```text
+First, you could query for the types associated with the node, as in the
+following example:
+
+```graphql
 {
   me(func: uid(0xff)) {
      dgraph.type
@@ -89,54 +128,63 @@ The other consequence of removing `_predicate_` is that it cannot be referenced 
 }
 ```
 
-And then retrieving the definition of each type in the results using a schema query.
+Next, you could fetch the definition of each type in the results using a schema
+query, as follows
 
-```text
+```graphql
 schema(type: Person) {}
 ```
 
 ## Live Loader and Bulk Loader command-line flags
 
-### File input flags
-In Dgraph v1.1, both the Dgraph Live Loader and Dgraph Bulk Loader tools support loading data in either RDF format or JSON format. To simplify the command-line interface for these tools, the `-r`/`--rdfs` flag has been removed in favor of `-f/--files`. The new flag accepts file or directory paths for either data format. By default, the tools will infer the file type based on the file suffix, e.g., `.rdf` and `.rdf.gz` or `.json` and `.json.gz` for RDF data or JSON data, respectively. To ignore the filenames and set the format explicitly, the `--format` flag can be set to `rdf` or `json`.
+A variety of command-line flags for Dgraph Live Loader and Dgraph Bulk Loader
+have changed in newer Dgraph versions.
 
-Before (in Dgraph v1.0):
+### File input flags
+
+In Dgraph {{< version >}}, both the Dgraph Live Loader and Dgraph Bulk Loader tools support loading data in either RDF format or JSON format. To simplify the command-line interface for these tools, the `-r`/`--rdfs` flag has been removed in favor of `-f/--files`. The new flag accepts file or directory paths for either data format. By default, the tools will infer the file type based on the file suffix, e.g., `.rdf` and `.rdf.gz` or `.json` and `.json.gz` for RDF data or JSON data, respectively. To ignore the filenames and set the format explicitly, the `--format` flag can be set to `rdf` or `json`.
+
+File input example for Dgraph v1.0:
 
 ```sh
 dgraph live -r data.rdf.gz
 ```
 
-Now (in Dgraph v1.1):
+File input example for newer Dgraph versions:
 
 ```sh
 dgraph live -f data.rdf.gz
 ```
 
 ### Dgraph Alpha address flag
-For Dgraph Live Loader, the flag to specify the Dgraph Alpha address  (default: `127.0.0.1:9080`) has changed from `-d`/`--dgraph` to `-a`/`--alpha`.
 
-Before (in Dgraph v1.0):
+For Dgraph Live Loader, the Dgraph Alpha address flag (default: `127.0.0.1:9080`)
+has changed from `-d`/`--dgraph` to `-a`/`--alpha`.
+
+Dgraph Alpha address example for Dgraph v1.0:
 
 ```sh
 dgraph live -d 127.0.0.1:9080
 ```
 
-Now (in Dgraph v1.1):
+Dgraph Alpha address example for newer Dgraph versions:
 
 ```sh
 dgraph live -a 127.0.0.1:9080
 ```
+
 ## HTTP API
 
-For HTTP API users (e.g., Curl, Postman), the custom Dgraph headers have been removed in favor of standard HTTP headers and query parameters.
+For HTTP API users (e.g., Curl, Postman), the custom Dgraph headers have been
+removed in favor of standard HTTP headers and query parameters.
 
 ### Queries
 
-There are two accepted `Content-Type` headers for queries over HTTP: `application/graphql+-` or `application/json`.
+There are two accepted `Content-Type` headers for queries over HTTP: `application/dql` or `application/json`.
 
 A `Content-Type` must be set to run a query.
 
-Before (in Dgraph v1.0):
+`curl` query example for Dgraph v1.0:
 
 ```sh
 curl localhost:8080/query -d '{
@@ -146,7 +194,7 @@ curl localhost:8080/query -d '{
 }'
 ```
 
-Now (in Dgraph v1.1):
+`curl` query example for newer Dgraph versions:
 
 ```sh
 curl -H 'Content-Type: application/graphql+-' localhost:8080/query -d '{
@@ -156,9 +204,11 @@ curl -H 'Content-Type: application/graphql+-' localhost:8080/query -d '{
 }'
 ```
 
-For queries using [GraphQL Variables]({{< relref "query-language/graphql-variables.md" >}}), the query must be sent via the `application/json` content type, with the query and variables sent in a JSON payload:
+For queries using [GraphQL Variables]({{< relref "query-language/graphql-variables.md" >}}),
+the query must be sent using the `application/json` content type, with the query
+and variables sent in a JSON payload:
 
-Before (in Dgraph v1.0):
+GraphQL variable example for Dgraph v1.0:
 
 ```sh
 curl -H 'X-Dgraph-Vars: {"$name": "Alice"}' localhost:8080/query -d 'query qWithVars($name: string) {
@@ -168,7 +218,7 @@ curl -H 'X-Dgraph-Vars: {"$name": "Alice"}' localhost:8080/query -d 'query qWith
 }
 ```
 
-Now (in Dgraph v1.1):
+GraphQL variable example for Dgraph {{< version >}}:
 
 ```sh
 curl -H 'Content-Type: application/json' localhost:8080/query -d '{
@@ -183,11 +233,11 @@ There are two accepted Content-Type headers for mutations over HTTP: `Content-Ty
 
 A `Content-Type` must be set to run a mutation.
 
-These Content-Type headers supercede the Dgraph v1.0.x custom header `X-Dgraph-MutationType` to set the mutation type as RDF or JSON.
+These Content-Type headers supersede the Dgraph v1.0.x custom header `X-Dgraph-MutationType` to set the mutation type as RDF or JSON.
 
 To commit the mutation immediately, use the query parameter `commitNow=true`. This replaces the custom header `X-Dgraph-CommitNow: true` from Dgraph v1.0.x.
 
-Before (in Dgraph v1.0)
+RDF mutation syntax example for Dgraph v1.0:
 
 ```sh
 curl -H 'X-Dgraph-CommitNow: true' localhost:8080/mutate -d '{
@@ -198,7 +248,7 @@ curl -H 'X-Dgraph-CommitNow: true' localhost:8080/mutate -d '{
 }'
 ```
 
-Now (in Dgraph v1.1):
+RDF mutation syntax example for newer Dgraph versions:
 
 ```sh
 curl -H 'Content-Type: application/rdf' localhost:8080/mutate?commitNow=true -d '{
@@ -211,7 +261,7 @@ curl -H 'Content-Type: application/rdf' localhost:8080/mutate?commitNow=true -d 
 
 For JSON mutations, set the `Content-Type` header to `application/json`.
 
-Before (in Dgraph v1.0):
+JSON mutation syntax example for Dgraph v1.0:
 
 ```sh
 curl -H 'X-Dgraph-MutationType: json' -H "X-Dgraph-CommitNow: true" localhost:8080/mutate -d '{
@@ -223,7 +273,7 @@ curl -H 'X-Dgraph-MutationType: json' -H "X-Dgraph-CommitNow: true" localhost:80
 }'
 ```
 
-Now (in Dgraph v1.1):
+JSON mutation syntax example for newer Dgraph versions:
 
 ```sh
 curl -H 'Content-Type: application/json' localhost:8080/mutate?commitNow=true -d '{


### PR DESCRIPTION
Cherry-pick of https://github.com/dgraph-io/dgraph/pull/7179 from `dgraph` repo to `dgraph-docs` repo's 20.07 branch. 

Reframes this content as migration from v1.0, instead of migration to v1.1

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
