### PR TITLE
Docs(audit logs): Add documentation for audit logging capabilities enabled with enterprise license

### DIFF
--- a/content/deploy/log-format.md
+++ b/content/deploy/log-format.md
@@ -1,6 +1,6 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
-title = "Log Format"
+title = "Logging"
 weight = 2
 [menu.main]
     parent = "admin"
@@ -102,3 +102,9 @@ mutation {
   }
 }
 ```
+
+## Audit logging (enterprise feature)
+
+With a Dgraph enterprise license, you can enable audit logging so that all
+requests are tracked and available for use in security audits. To learn more, see
+[Audit Logging]({{< relref "enterprise-features/audit-logs.md" >}}).

--- a/content/deploy/log-format.md
+++ b/content/deploy/log-format.md
@@ -1,10 +1,13 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
 title = "Logging"
+description = "Dgraph provides request logging, and also provides audit logging capabilities with a Dgraph Enterprise license."
 weight = 2
 [menu.main]
     parent = "admin"
 +++
+
+Dgraph provides request (query and mutation) logging, and also provides audit logging capabilities with a Dgraph Enterprise license.
 
 Dgraph's log format comes from the glog library and is [formatted](https://github.com/golang/glog/blob/23def4e6c14b4da8ac2ed8007337bc5eb5007998/glog.go#L523-L533) as follows:
 
@@ -32,9 +35,10 @@ To increase log verbosity, you have set the flag `-v=3` (or `-v=2`) which will e
 This requires a restart of the node itself.
 {{% /notice %}}
 
-## Query Logging
+## Request logging Logging
 
-You can dynamically turn query logging on or off. To toggle query logging on, send the following GraphQL mutation to the `/admin` endpoint of an Alpha node (e.g. `localhost:8080/admin`):
+Request logging, sometimes called *query logging*, lets you log queries and mutations.
+You can dynamically turn request logging on or off. To toggle request logging on, send the following GraphQL mutation to the `/admin` endpoint of an Alpha node (e.g. `localhost:8080/admin`):
 
 ```graphql
 mutation {
@@ -73,12 +77,12 @@ Also, the Alpha node will print the following INFO message to confirm that the m
 I1207 14:53:28.240516   20143 config.go:39] Got config update through GraphQL admin API
 ```
 
-When enabling query logging this prints the queries/mutation that Dgraph Alpha receives from Ratel, Client etc. In this case, the Alpha log will print something similar to:
+When enabling request logging this prints the requests that Dgraph Alpha receives from Ratel or other clients. In this case, the Alpha log will print something similar to:
 
 ```
 I1201 13:06:26.686466   10905 server.go:908] Got a query: query:"{\n  query(func: allofterms(name@en, \"Marc Caro\")) {\n  uid\n  name@en\n  director.film\n  }\n}"  
 ```
-As you can see, we got the query that Alpha received, to read it in the original DQL format just replace every `\n` with a new line, any `\t` with a tab character and `\"` with `"`:
+As you can see, we got the query that Alpha received. To read it in the original DQL format just replace every `\n` with a new line, any `\t` with a tab character and `\"` with `"`:
 
 ```
 {
@@ -90,7 +94,7 @@ As you can see, we got the query that Alpha received, to read it in the original
 }
 ```
 
-Similarly, you can turn off query logging by setting `logRequest` to `false` in the `/admin` mutation.
+Similarly, you can turn off request logging by setting `logRequest` to `false` in the `/admin` mutation.
 
 ```graphql
 mutation {

--- a/content/enterprise-features/audit-logs.md
+++ b/content/enterprise-features/audit-logs.md
@@ -112,3 +112,7 @@ as follows:
 ```bash
 dgraph audit decrypt --encryption_key_file /path/encrypt/key/file --in /path/to/encrypted/log/file --out /path/to/output/file
 ```
+
+## Next steps
+
+To learn more about the logging features of Dgraph, see [Logging]({{< relref "deploy/log-format.md" >}}).

--- a/content/enterprise-features/audit-logs.md
+++ b/content/enterprise-features/audit-logs.md
@@ -8,16 +8,19 @@ weight = 2
 +++
 
 As a database administrator, you count on being able to audit access to your
-database. With a Dgraph enterprise license, you can enable audit logging so that
-all requests are tracked and available for use in security audits. When audit logging
-is enabled, the following information is recorded about the queries and mutations (requests)
-sent to your database:
+database. With a Dgraph 
+[enterprise license]({{< relref "enterprise-features/license.md" >}}), you can
+enable audit logging so that all requests are tracked and available for use in
+security audits. When audit logging is enabled, the following information is
+recorded about the queries and mutations (requests) sent to your database:
 
 * Endpoint
 * Logged-in User Name
 * Server host address
 * Client Host address
 * Request Body (truncated at 4KB)
+* Timestamp
+* Namespace
 * Query Parameters (if provided)
 * Response status
 
@@ -41,18 +44,24 @@ The following are not logged:
 ## Audit log files
 
 All audit logs are in JSON format. Dgraph has a "rolling-file" policy for audit
-logs, where the current log file is used until it reaches 100MB, and then
-is replaced by another current audit log file. Older audit log files are
-retained for a maximum of 10 days.
+logs, where the current log file is used until it reaches a configurable size
+(default: 100MB), and then is replaced by another current audit log file. Older
+audit log files are retained for a configurable number of days (default: 10 days).
 
 ## Enable audit logging
 
 You can enable audit logging on a Dgraph Alpha or Dgraph Zero node by using the
-`--audit` flag to specify a directory where audit logs should be stored. When
+`--audit` flag to specify semicolon-separated options for audit logging. When
 you enable audit logging, a few options are available for you to configure:
 
 * `compress=true` tells Dgraph to use compression on older audit log files
-* `encrypt_file=/encryption/key/path` tells Dgraph to encrypt older log files with the specified key
+* `days=20` tells Dgraph to retain older audit logs for 20 days, rather than the
+default of 10 days
+* `dir=/path/to/audit/logs` tells Dgraph which path to use for storing audit logs
+* `encrypt_file=/encryption/key/path` tells Dgraph to encrypt older log files
+ with the specified key
+* `size=200` tells Dgraph to store audit logs in 200 MB files,  rather than the
+default of 100 MB files
 
 You can see how to use these options in the example commands below.
 
@@ -67,6 +76,13 @@ directory to store audit logs on a Dgraph Alpha node:
 
 ```bash
 dgraph alpha --audit dir=audit-log-dir
+```
+
+You could extend this command a bit to specify larger log files (200 MB, instead
+of 100 MB) and retain them for longer (15 days instead of 10 days):
+
+```bash
+dgraph alpha --audit dir=audit-log-dir;size=200;days=15
 ```
 
 ### Enable audit logging with compression

--- a/content/enterprise-features/audit-logs.md
+++ b/content/enterprise-features/audit-logs.md
@@ -1,0 +1,98 @@
++++
+date = "2017-03-20T22:25:17+11:00"
+title = "Audit Logging"
+description = "With an Enterprise license, Dgraph can generate audit logs that let you track and audit all requests (queries and mutations)."
+weight = 2
+[menu.main]
+    parent = "enterprise-features"
++++
+
+As a database administrator, you count on being able to audit access to your
+database. With a Dgraph enterprise license, you can enable audit logging so that
+all requests are tracked and available for use in security audits. When audit logging
+is enabled, the following information is recorded about the queries and mutations (requests)
+sent to your database:
+
+* Endpoint
+* Logged-in User Name
+* Server host address
+* Client Host address
+* Request Body (truncated at 4KB)
+* Query Parameters (if provided)
+* Response status
+
+## Audit log scope
+
+Most queries and mutations sent to Dgraph Alpha and Dgraph Zero are logged.
+Specifically, the following are logged:
+
+* HTTP requests sent over Dgraph Zero's 6080 port and Dgraph Alpha's 8080 port (except as noted below)
+* GRPC requests sent over Dgraph Zero's 5080 port and Dgraph Alpha's 9080 port (except the Raft, health and Dgraph Zero stream endpoints noted below)
+
+The following are not logged:
+
+* Responses to queries and mutations
+* HTTP requests to `/health`, `/state` and `/jemalloc` endpoints
+* GRPC requests to Raft endpoints (see [RAFT]({{< relref "design-concepts/raft.md" >}}))
+* GRPC requests to health endpoints (`Check` and `Watch`)
+* GRPC requests to Dgraph Zero stream endpoints (`StreamMembership`, `UpdateMembership`, `Oracle`, `Timestamps`, `ShouldServe` and `Connect`)
+<!-- We don't have any docs to link to for the endpoints described in the last two bullets. TBD fix this so we are't referencing something not described elsewhere -->
+
+## Audit log files
+
+All audit logs are in JSON format. Dgraph has a "rolling-file" policy for audit
+logs, where the current log file is used until it reaches 100MB, and then
+is replaced by another current audit log file. Older audit log files are
+retained for a maximum of 10 days.
+
+## Enable audit logging
+
+You can enable audit logging on a Dgraph Alpha or Dgraph Zero node by using the
+`--audit` flag to specify a directory where audit logs should be stored. When
+you enable audit logging, a few options are available for you to configure:
+
+* `compress=true` tells Dgraph to use compression on older audit log files
+* `encrypt_file=/encryption/key/path` tells Dgraph to encrypt older log files with the specified key
+
+You can see how to use these options in the example commands below.
+
+## Example commands
+
+The commands in this section show you how to enable and configure audit logging.
+
+### Enable audit logging
+
+In the simplest scenario, you can enable audit logging by simply specifying the 
+directory to store audit logs on a Dgraph Alpha node:
+
+```bash
+dgraph alpha --audit dir=audit-log-dir
+```
+
+### Enable audit logging with compression
+
+In many cases you will want to compress older audit logs to save storage space.
+You can do this with a command like the following:
+
+```bash
+dgraph alpha --audit dir=audit-log-dir;compress=true
+```
+
+### Enable audit logging with encryption
+
+You can also enable encryption of audit logs to protect sensitive information that
+might exist in logged requests. You can do this, along with compression, with a
+command like the following:
+
+```bash
+dgraph alpha --audit dir=audit-log-dir;compress=true;encrypt_file=/path/to/encrypt/key/file
+```
+
+### Decrypt audit logs
+
+To decrypt encrypted audit logs, you can use the `dgraph audit decrypt` command,
+as follows:
+
+```bash
+dgraph audit decrypt --encryption_key_file /path/encrypt/key/file --in /path/to/encrypted/log/file --out /path/to/output/file
+```


### PR DESCRIPTION
Staged here: https://deploy-preview-74--dgraph-docs-repo.netlify.app/enterprise-features/audit-logs/

Fixes Doc-159

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
