### PR TITLE
[v20.11 cherry-pick]  Add "code" messages errors for "/query" endpoint (#76)

### DIFF
--- a/content/query-language/graphql-fundamentals.md
+++ b/content/query-language/graphql-fundamentals.md
@@ -75,8 +75,8 @@ For example, you can get this error:
   - If the value of these query parameters is incorrect you would get this error code. This is basically a bad request (`400`)
 - If the header's `Content-Type` value is not parsed correctly. The only allowed content types in the header are: 
   - `application/json`
-  - `application/graphql+-` (deprecated)
   - `application/dql`
+  - `application/graphql+-` (deprecated)
   - Anything else will be wrongly parsed and end up in a bad request (`400`)
 - Query timeout (deadline exceeded). This is an internal server error (`500`)
 - Any error in query processing like:

--- a/content/query-language/graphql-fundamentals.md
+++ b/content/query-language/graphql-fundamentals.md
@@ -75,7 +75,7 @@ For example, you can get this error:
   - If the value of these query parameters is incorrect you would get this error code. This is basically a bad request (`400`)
 - If the header's `Content-Type` value is not parsed correctly. The only allowed content types in the header are: 
   - `application/json`
-  - `application/graphql+-`
+  - `application/graphql+-` (deprecated)
   - `application/dql`
   - Anything else will be wrongly parsed and end up in a bad request (`400`)
 - Query timeout (deadline exceeded). This is an internal server error (`500`)
@@ -83,7 +83,7 @@ For example, you can get this error:
   - syntax error - bad request (`400`)
   - health failing (server not healthy) - internal server error (`500`)
   - Alpha not able to reach zero because of network issue - internal server error (`500`)
-  - ACL error (user not found or user does not have privileges) - bad request (`400`)
+  - ACL error (user not found or user does not have privileges) - unauthenticated/unauthorized request (`401` or `403`)
   - if you set `be=true` and `ro=false` - bad request (`400`)
   - any error related to JSON formatting the response - internal server error (`500`)
 

--- a/content/query-language/graphql-fundamentals.md
+++ b/content/query-language/graphql-fundamentals.md
@@ -29,6 +29,64 @@ A query is composed of nested blocks, starting with a query root.  The root find
 
 {{% notice "note" %}}See more about Queries in [Queries design concept]({{< relref "design-concepts/concepts.md#queries" >}}) {{% /notice %}}
 
+### Error Codes
+
+When running a DQL query you might get an error message from the `/query` endpoint.
+Here we will be focusing on the error `"code"` returned in the JSON error object.
+
+You can usually get two types of error codes:
+- [`ErrorInvalidRequest`](#errorinvalidrequest): this error can be either a bad request (`400`) or an internal server error (`500`).
+- [`Error`](#error): this is an internal server error (`500`)
+
+For example, if you submit a query with a syntax error, you'll get:
+
+```json
+{
+  "errors": [
+    {
+      "message": "while lexing {\nq(func: has(\"test)){\nuid\n}\n} at line 2 column 12: Unexpected end of input.",
+      "extensions": {
+        "code": "ErrorInvalidRequest"
+      }
+    }
+  ],
+  "data": null
+}
+```
+The error `"code"` value is returned with the query response.
+In this case, it's a syntax error and the error `code` is `ErrorInvalidRequest`.
+
+##### `Error`
+
+This is a rare code to get and it's always an internal server error (`500`).
+This can happen when JSON marsharling is failing (it's returned when the system tries to marshal a Go struct to JSON)
+
+##### `ErrorInvalidRequest`
+
+This is the most common error code that you can get from the `/query` endpoint. This error can be either a bad request (`400`) or an internal server error (`500`).
+
+For example, you can get this error:
+- If the query parameter is not being parsed correctly. The query parameter could be:
+  - `debug`
+  - `timeout`
+  - `startTs` 
+  - `be` (best effort) 
+  - `ro` (read-only)
+  - If the value of these query parameters is incorrect you would get this error code. This is basically a bad request (`400`)
+- If the header's `Content-Type` value is not parsed correctly. The only allowed content types in the header are: 
+  - `application/json`
+  - `application/graphql+-`
+  - `application/dql`
+  - Anything else will be wrongly parsed and end up in a bad request (`400`)
+- Query timeout (deadline exceeded). This is an internal server error (`500`)
+- Any error in query processing like:
+  - syntax error - bad request (`400`)
+  - health failing (server not healthy) - internal server error (`500`)
+  - Alpha not able to reach zero because of network issue - internal server error (`500`)
+  - ACL error (user not found or user does not have privileges) - bad request (`400`)
+  - if you set `be=true` and `ro=false` - bad request (`400`)
+  - any error related to JSON formatting the response - internal server error (`500`)
+
 ## Returning Values
 
 Each query has a name, specified at the query root, and the same name identifies the results.


### PR DESCRIPTION
This PR adds the two types of code error you would get from the /query endpoint

(cherry picked from commit 1ad62b68da4749de5f668c5de0420e3941ff8b8e)
