### PR TITLE
Docs (GraphQL): 21.03 feature documentation for GraphQL Upserts

### DIFF
--- a/content/graphql/mutations/add.md
+++ b/content/graphql/mutations/add.md
@@ -31,7 +31,7 @@ type Post {
 Dgraph automatically generates input and return types in the schema for the add mutation, 
 as shown below:
 ```graphql
-addPost(input: [AddPostInput!]!, upsert: Boolean): AddPostPayload
+addPost(input: [AddPostInput!]!): AddPostPayload
 
 input AddPostInput {
 	title: String!

--- a/content/graphql/mutations/add.md
+++ b/content/graphql/mutations/add.md
@@ -31,7 +31,7 @@ type Post {
 Dgraph automatically generates input and return types in the schema for the add mutation, 
 as shown below:
 ```graphql
-addPost(input: [AddPostInput!]!): AddPostPayload
+addPost(input: [AddPostInput!]!, upsert: Boolean): AddPostPayload
 
 input AddPostInput {
 	title: String!
@@ -77,6 +77,10 @@ Variables:
   }
 }
 ```
+
+{{% notice "note" %}}
+You can convert an `add` mutation to an `upsert` mutation by setting the value of the input variable `upsert` to `true`. For more information, see [Upsert Mutations](/graphql/mutations/upsert).
+{{% /notice %}}
 
 ## Examples
 

--- a/content/graphql/mutations/upsert.md
+++ b/content/graphql/mutations/upsert.md
@@ -7,9 +7,9 @@ weight = 2
     name = "Upsert"
 +++
 
-Upsert mutations allow you to perform `add` or `update` operations based on whether a particular ID exists in the database. The IDs must be external IDs, defined using the `@id` directive in the schema.
+Upsert mutations allow you to perform `add` or `update` operations based on whether a particular `ID` exists in the database. The IDs must be external IDs, defined using the `@id` directive in the schema.
 
-We use the following schema to demonstrate how upserts work in GraphQL:
+For example, to demonstrate how upserts work in GraphQL, take the following schema:
 
 **Schema**
 ```graphql
@@ -29,7 +29,7 @@ type Post {
 }
 ```
 
-Dgraph automatically generates input and return types in the schema for the add mutation, as shown below:
+Dgraph automatically generates input and return types in the schema for the `add` mutation, as shown below:
 
 ```graphql
 addPost(input: [AddPostInput!]!): AddPostPayload
@@ -43,9 +43,9 @@ input AddPostInput {
 }
 ```
 
-Suppose we want to update the `text` field of a post with the ID `mm2`. But we also want to create a new post with that ID in case it doesn't already exist. To do this, we use the `addPost` mutation, but with an additional input variable `upsert`.  
+Suppose you want to update the `text` field of a post with the ID `mm2`. But you also want to create a new post with that ID in case it doesn't already exist. To do this, you use the `addPost` mutation, but with an additional input variable `upsert`.  
 
-This is a Boolean variable. Setting it to `true` will change the default behavior of an `add` operation to an upsert operation.
+This is a `Boolean` variable. Setting it to `true` will change the default behavior of an `add` operation to an upsert operation.
 
 It will perform an `update` mutation and carry out the changes you specify in your request if the particular ID exists. Otherwise, it will fall back to a default `add` operation and create a new `Post` with that ID and the details you provide.
 
@@ -104,9 +104,9 @@ If a post with the ID `mm2` exists, it will update the post with the new details
 ```
 
 {{% notice "note" %}}
-* The default value of `uspert` will be false, for backward compatibility.
+* The default value of `uspert` will be `false`, for backward compatibility.
 * Upsert operations are only relevant for types containing an `@id` field. Performing an `add` mutation with `upsert` set to `true` for a type that doesn't have any `@id` field will have no effect.
-* The current behavior of Add and Update mutations is such that they do not update deep level nodes. So Add mutations with `upsert` set to `true` will only update values at the root level. 
+* The current behavior of `Add` and `Update` mutations is such that they do not update deep level nodes. So Add mutations with `upsert` set to `true` will only update values at the root level. 
 {{% /notice %}}
 
 ## Examples

--- a/content/graphql/mutations/upsert.md
+++ b/content/graphql/mutations/upsert.md
@@ -16,7 +16,6 @@ For example, to demonstrate how upserts work in GraphQL, take the following sche
 type Author {
 	id: String! @id
 	name: String! @search(by: [hash])
-	dob: DateTime
 	posts: [Post] @hasInverse(field: author)
 }
 
@@ -24,28 +23,26 @@ type Post {
 	postID: String! @id
 	title: String! @search(by: [term, fulltext])
 	text: String @search(by: [fulltext, term])
-    author: Author!
-	datePublished: DateTime
+	author: Author!
 }
 ```
 
 Dgraph automatically generates input and return types in the schema for the `add` mutation, as shown below:
 
 ```graphql
-addPost(input: [AddPostInput!]!): AddPostPayload
+addPost(input: [AddPostInput!]!, upsert: Boolean): AddPostPayload
 
 input AddPostInput {
   postID: String!
   title: String!
   text: String
   author: AuthorRef!
-  datePublished: DateTime
 }
 ```
 
 Suppose you want to update the `text` field of a post with the ID `mm2`. But you also want to create a new post with that ID in case it doesn't already exist. To do this, you use the `addPost` mutation, but with an additional input variable `upsert`.  
 
-This is a `Boolean` variable. Setting it to `true` will change the default behavior of an `add` operation to an upsert operation.
+This is a `Boolean` variable. Setting it to `true` will result in an upsert operation.
 
 It will perform an `update` mutation and carry out the changes you specify in your request if the particular ID exists. Otherwise, it will fall back to a default `add` operation and create a new `Post` with that ID and the details you provide.
 
@@ -105,7 +102,6 @@ If a post with the ID `mm2` exists, it will update the post with the new details
 
 {{% notice "note" %}}
 * The default value of `uspert` will be `false`, for backward compatibility.
-* Upsert operations are only relevant for types containing an `@id` field. Performing an `add` mutation with `upsert` set to `true` for a type that doesn't have any `@id` field will have no effect.
 * The current behavior of `Add` and `Update` mutations is such that they do not update deep level nodes. So Add mutations with `upsert` set to `true` will only update values at the root level. 
 {{% /notice %}}
 

--- a/content/graphql/mutations/upsert.md
+++ b/content/graphql/mutations/upsert.md
@@ -1,0 +1,113 @@
++++
+title = "Upsert Mutations"
+description = "Upsert mutations allow you to perform `add` or `update` operations based on whether a particular ID exists in the database"
+weight = 2
+[menu.main]
+    parent = "graphql-mutations"
+    name = "Upsert"
++++
+
+Upsert mutations allow you to perform `add` or `update` operations based on whether a particular ID exists in the database. The IDs must be external IDs, defined using the `@id` directive in the schema.
+
+We use the following schema to demonstrate how upserts work in GraphQL:
+
+**Schema**
+```graphql
+type Author {
+	id: String! @id
+	name: String! @search(by: [hash])
+	dob: DateTime
+	posts: [Post] @hasInverse(field: author)
+}
+
+type Post {
+	postID: String! @id
+	title: String! @search(by: [term, fulltext])
+	text: String @search(by: [fulltext, term])
+    author: Author!
+	datePublished: DateTime
+}
+```
+
+Dgraph automatically generates input and return types in the schema for the add mutation, as shown below:
+
+```graphql
+addPost(input: [AddPostInput!]!): AddPostPayload
+
+input AddPostInput {
+  postID: String!
+  title: String!
+  text: String
+  author: AuthorRef!
+  datePublished: DateTime
+}
+```
+
+Suppose we want to update the `text` field of a post with the ID `mm2`. But we also want to create a new post with that ID in case it doesn't already exist. To do this, we use the `addPost` mutation, but with an additional input variable `upsert`.  
+
+This is a Boolean variable. Setting it to `true` will change the default behavior of an `add` operation to an upsert operation.
+
+It will perform an `update` mutation and carry out the changes you specify in your request if the particular ID exists. Otherwise, it will fall back to a default `add` operation and create a new `Post` with that ID and the details you provide.
+
+Setting `upsert` to `false` is the same as using a plain `add` operation—it'll either fail or succeed, depending on whether the ID exists or not.
+
+**Example**: Add mutation with `upsert` true:
+
+```graphql
+mutation($post: [AddPostInput!]!) {
+  addPost(input: $post, upsert: true) {
+    post {
+      postID
+      title
+      text
+      author {
+        id
+      }
+    }
+  }
+}
+```
+
+With variables:
+
+```json
+{
+	"post": 
+  {
+		"postID": "mm2",
+		"title": "Second Post",
+		"text": "This is my second post, and updated with some new information.",
+		"author": {
+			"id": "micky"
+		}
+	}
+}
+```
+
+If a post with the ID `mm2` exists, it will update the post with the new details. Otherwise, it'll create a new `Post` with that ID and the values you provided. In either case, you'll get the following response back:
+
+```graphql
+"data": {
+    "addPost": {
+      "post": [
+        {
+          "postID": "mm2",
+          "title": "Second Post",
+          "text": "This is my second post, and updated with some new information.",
+          "author": {
+            "id": "micky"
+          }
+        }
+      ]
+    }
+  }
+```
+
+{{% notice "note" %}}
+* The default value of `uspert` will be false, for backward compatibility.
+* Upsert operations are only relevant for types containing an `@id` field. Performing an `add` mutation with `upsert` set to `true` for a type that doesn't have any `@id` field will have no effect.
+* The current behavior of Add and Update mutations is such that they do not update deep level nodes. So Add mutations with `upsert` set to `true` will only update values at the root level. 
+{{% /notice %}}
+
+## Examples
+You can refer to the following [link](https://github.com/dgraph-io/dgraph/blob/master/graphql/resolve/add_mutation_test.yaml) for more examples.

--- a/content/howto/upserts.md
+++ b/content/howto/upserts.md
@@ -46,11 +46,13 @@ in the `Assigned` object returned from the mutation.
    modify the account (using additional mutations) or perform queries on it in
 whichever way you wish.
 
-## Upsert Block
+## Upserts in DQL and GraphQL
 
-You can also use the `Upsert Block` to achieve the upsert procedure in a single
+You can also use the `Upsert Block` in DQL to achieve the upsert procedure in a single
  mutation. The request will contain both the query and the mutation as explained
 [here]({{< relref "mutations/upsert-block.md" >}}).
+
+In GraphQL, you can use the `upsert` input variable in an `add` mutation, as explained [here]({{< relref "graphql/mutations/upsert.md">}}).
 
 ## Conflicts
 


### PR DESCRIPTION
Documentation for GraphQL upserts as per PR: https://github.com/dgraph-io/dgraph/pull/7433.
Fixes [DOC-167](https://dgraph.atlassian.net/browse/DOC-167).
Preview [here](https://deploy-preview-88--dgraph-docs-repo.netlify.app/graphql/mutations/upsert/).