### PR TITLE
docs(clients): Add multi-tenancy to Dgraph client docs

### DIFF
--- a/content/clients/go.md
+++ b/content/clients/go.md
@@ -86,7 +86,7 @@ if err := dc.LoginIntoNamespace(ctx, "groot", "password", 123); err != nil {
 ```
 
 In the example above, the client logs into namespace `123` using username `groot` and password `password`.
-This client will be able to access all the data which is accessible to the `groot` user in the namespace `123`.
+Once logged in, the client can perform all the operations allowed to the `groot` user of namespace `123`.
 
 ## Alter the database
 

--- a/content/clients/go.md
+++ b/content/clients/go.md
@@ -65,7 +65,7 @@ func newClient() *dgo.Dgraph {
 
 ```
 
-#### Multi-tenancy
+### Multi-tenancy
 
 In [multi-tenancy]({{< relref "multitenancy.md" >}}) environments, Dgraph provides a new method `LoginIntoNamespace()`,
 which will allow the users to login to a specific namespace.

--- a/content/clients/go.md
+++ b/content/clients/go.md
@@ -65,6 +65,29 @@ func newClient() *dgo.Dgraph {
 
 ```
 
+#### Multi-tenancy
+
+In [multi-tenancy]({{< relref "multitenancy.md" >}}) environments, Dgraph provides a new method `LoginIntoNamespace()`,
+which will allow the users to login to a specific namespace.
+
+In order to create a dgo client, and make the client login into namespace `123`:
+
+```go
+conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
+if err != nil {
+	glog.Error("While trying to dial gRPC, got error", err)
+}
+dc := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+ctx := context.Background()
+// Login to namespace 123
+if err := dc.LoginIntoNamespace(ctx, "groot", "password", 123); err != nil {
+	glog.Error("Failed to login: ",err)
+}
+```
+
+In the example above, the client logs into namespace `123` using username `groot` and password `password`.
+This client will be able to access all the data which is accessible to the `groot` user in the namespace `123`.
+
 ## Alter the database
 
 To set the schema, set it on a `api.Operation` object, and pass it down to

--- a/content/clients/java.md
+++ b/content/clients/java.md
@@ -62,6 +62,15 @@ DgraphStub stub3 = DgraphGrpc.newStub(channel3);
 DgraphClient dgraphClient = new DgraphClient(stub1, stub2, stub3);
 ```
 
+#### Multi-tenancy
+
+If [multi-tenancy]({{< relref "multitenancy.md" >}}) is enabled, by default the login method on client will login into the namespace `0`.
+In order to login into some other namespace, do this:
+
+```java
+dgraphClient.loginIntoNamespace(USER_ID, USER_PASSWORD, NAMESPACE);
+```
+
 ### Creating a Client for Slash GraphQL Endpoint
 
 If you want to connect to Dgraph running on your [Slash GraphQL](https://slash.dgraph.io) instance, then all you need is the URL of your Slash GraphQL endpoint and the API key. You can get a client using them as follows :

--- a/content/clients/java.md
+++ b/content/clients/java.md
@@ -61,7 +61,7 @@ DgraphStub stub3 = DgraphGrpc.newStub(channel3);
 
 DgraphClient dgraphClient = new DgraphClient(stub1, stub2, stub3);
 ```
-#### Login using ACL
+### Login using ACL
 
 If [ACL]({{< relref "access-control-lists.md" >}}) is enabled then you can log-in to the default namespace (`0`) with the following method:
 
@@ -69,7 +69,7 @@ If [ACL]({{< relref "access-control-lists.md" >}}) is enabled then you can log-i
 dgraphClient.login(USER_ID, USER_PASSWORD);
 ```
 
-#### Multi-tenancy
+### Multi-tenancy
 
 If [multi-tenancy]({{< relref "multitenancy.md" >}}) is enabled, by default the login method on client will login into the namespace `0`.
 In order to login into some other namespace, use the `loginIntoNamespace` method on the client:
@@ -135,12 +135,6 @@ Checking the version, before doing anything else can be used as a test to find o
 is able to communicate with the Dgraph server. This will also help reduce the latency of the first
 query/mutation which results from some dynamic library loading and linking that happens in JVM
 (see [this issue](https://github.com/dgraph-io/dgraph4j/issues/108) for more details).
-
-### Login Using ACL
-
-```java
-dgraphClient.login(USER_ID, USER_PASSWORD);
-```
 
 ### Altering the Database
 

--- a/content/clients/java.md
+++ b/content/clients/java.md
@@ -61,15 +61,24 @@ DgraphStub stub3 = DgraphGrpc.newStub(channel3);
 
 DgraphClient dgraphClient = new DgraphClient(stub1, stub2, stub3);
 ```
+#### Login using ACL
+
+If [ACL]({{< relref "access-control-lists.md" >}}) is enabled then you can log-in to the default namespace (`0`) with the following method:
+
+```java
+dgraphClient.login(USER_ID, USER_PASSWORD);
+```
 
 #### Multi-tenancy
 
 If [multi-tenancy]({{< relref "multitenancy.md" >}}) is enabled, by default the login method on client will login into the namespace `0`.
-In order to login into some other namespace, do this:
+In order to login into some other namespace, use the `loginIntoNamespace` method on the client:
 
 ```java
 dgraphClient.loginIntoNamespace(USER_ID, USER_PASSWORD, NAMESPACE);
 ```
+
+Once logged-in, the `dgraphClient` object can be used to do any further operations.
 
 ### Creating a Client for Slash GraphQL Endpoint
 

--- a/content/clients/javascript/grpc.md
+++ b/content/clients/javascript/grpc.md
@@ -62,6 +62,21 @@ const dgraphClient = new dgraph.DgraphClient(clientStub);
 
 To facilitate debugging, [debug mode](#debug-mode) can be enabled for a client.
 
+### Multi-tenancy
+
+In [multi-tenancy]({{< relref "multitenancy.md" >}}) environments, `dgraph-js` provides a new method `loginIntoNamespace()`,
+which will allow the users to login to a specific namespace.
+
+In order to create a JavaScript client, and make the client login into namespace `123`:
+
+```js
+const dgraphClientStub = new dgraph.DgraphClientStub("localhost:9080");
+await dgraphClientStub.loginIntoNamespace("groot", "password", 123); // where 123 is the namespaceId 
+```
+
+In the example above, the client logs into namespace `123` using username `groot` and password `password`.
+Once logged in, the client can perform all the operations allowed to the `groot` user of namespace `123`.
+
 ### Creating a Client for Slash GraphQL Endpoint
 
 If you want to connect to Dgraph running on your [Slash GraphQL](https://slash.dgraph.io) instance, then all you need is the URL of your Slash GraphQL endpoint and the API key. You can get a client using them as follows:

--- a/content/clients/python.md
+++ b/content/clients/python.md
@@ -41,6 +41,23 @@ client_stub = pydgraph.DgraphClientStub('localhost:9080')
 client = pydgraph.DgraphClient(client_stub)
 ```
 
+### Multi-tenancy
+
+In [multi-tenancy]({{< relref "multitenancy.md" >}}) environments, PyDgraph provides a new method `login_in_namespace()`,
+which will allow the users to login to a specific namespace.
+
+In order to create a python client, and make the client login into namespace `123`:
+
+```python
+client_stub = pydgraph.DgraphClientStub('localhost:9080')
+client = pydgraph.DgraphClient(client_stub)
+// Login to namespace groot user of namespace 123
+client.login_in_namespace("groot", "password", "123")
+```
+
+In the example above, the client logs into namespace `123` using username `groot` and password `password`.
+Once logged in, the client can perform all the operations allowed to the `groot` user of namespace `123`.
+
 ### Creating a Client for Slash GraphQL Endpoint
 
 If you want to connect to Dgraph running on your [Slash GraphQL](https://slash.dgraph.io) instance, then all you need is the URL of your Slash GraphQL endpoint and the API key. You can get a client using them as follows:


### PR DESCRIPTION
Fixes DOC-183

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
