### PR TITLE
chore(fix): ACL update

### DIFF
--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -31,7 +31,7 @@ To use the Access Control List (ACL) features, you need to run Dgraph in Enterpr
 
 Dgraph enterprise features are enabled by default in a new cluster for 30 days. After the trial period of thirty days, the cluster must obtain a license from Dgraph to continue using the enterprise features released in the proprietary code.
 
-If you have a [License](https://dgraph.io/docs/enterprise-features/license/), you can supply the license key to the Zero server with:
+If you have a [License](https://dgraph.io/docs/enterprise-features/license/), you can supply the license key to the Dgraph Zero leader node with:
 
 ```bash
 dgraph zero --enterprise_license=PATH_TO_LICENSE_KEY
@@ -49,12 +49,12 @@ a contract with Dgraph Labs Inc. You can contact us by sending an email to
 forum](https://discuss.dgraph.io) to get an enterprise license.
 
 2. Create a plain text file, and store a randomly generated secret key in it. The secret
-key is used by Alpha servers to sign JSON Web Tokens (JWT). As you’ve probably guessed,
+key is used by Dgraph Alpha nodes to sign JSON Web Tokens (JWT). As you’ve probably guessed,
 it’s critical to keep the secret key as a secret. Another requirement for the secret key
 is that it must have at least 256-bits, i.e. 32 ASCII characters, as we are using
 HMAC-SHA256 as the signing algorithm.
 
-3. Start all the alpha servers in your cluster with the option `--acl_secret_file`, and
+3. Start all the Dgraph Alpha nodes in your cluster with the option `--acl_secret_file`, and
 make sure they are all using the same secret key file created in Step 2.
 
    ```bash
@@ -63,7 +63,7 @@ make sure they are all using the same secret key file created in Step 2.
 
 ### Example
 
-Here is an example that starts a Dgraph Zero server and a Dgraph Alpha server with the ACL feature turned on.  You can run these commands in a seperate terminal tab:
+Here is an example that starts a Dgraph Zero node and a Dgraph Alpha node with the ACL feature turned on.  You can run these commands in a seperate terminal tab:
 
 ```bash
 dgraph zero --my=localhost:5080 --replicas 1 --idx 1

--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -21,10 +21,7 @@ is only allowed to access the data permitted by the ACL rules.
 The ACL feature can be turned on by following these steps:
 
 1. Create a plain text file, and store a randomly generated secret key in it. The secret
-key is used by Dgraph Alpha nodes to sign JSON Web Tokens (JWT). As you’ve probably guessed,
-it’s critical to keep the secret key as a secret. Another requirement for the secret key
-is that it must have at least 256-bits, i.e. 32 ASCII characters, as we are using
-HMAC-SHA256 as the signing algorithm.
+key is used by Dgraph Alpha nodes to sign JSON Web Tokens (JWT).  Keep this secret key secret to avoid data security issues.  The secret key must have at least 256-bits (32 ASCII characters) to support the HMAC-SHA256 signing algorithm.
 
 2. Start all the Dgraph Alpha nodes in your cluster with the option `--acl_secret_file`, and
 make sure they are all using the same secret key file created in Step 2.
@@ -34,7 +31,7 @@ make sure they are all using the same secret key file created in Step 2.
    ```
 
 {{% notice "tip" %}}
-In addition to command line flags `--acl_secret_file` and `--whitelist`, you can also configure Dgraph with a configuration file, e.g. `config.properties`, `config.yaml`, `config.json`, `config.toml`, `config.hcl`.  You can also use environment variables, i.e. `DGRAPH_ALPHA_ACL_SECRET_FILE` and `DGRAPH_ALPHA_WHITELIST`. See [Config]({{< relref "config" >}}) for more information in general about configuring Dgraph.
+In addition to command line flags `--acl_secret_file` and `--whitelist`, you can also configure Dgraph using a configuration file (`config.properties`, `config.yaml`, `config.json`, `config.toml` or `config.hcl`).  You can also use environment variables, i.e. `DGRAPH_ALPHA_ACL_SECRET_FILE` and `DGRAPH_ALPHA_WHITELIST`. See [Config]({{< relref "config" >}}) for more information in general about configuring Dgraph.
 {{% /notice %}}
 
 ### Example using Dgraph CLI
@@ -56,7 +53,7 @@ dgraph alpha --my=localhost:7080 --zero=localhost:5080 \
 
 ### Example using Docker Compose
 
-If you are using [Docker Compose](https://docs.docker.com/compose/), a sample cluster can be set up using this `docker-compose.yaml` configuration:
+If you are using [Docker Compose](https://docs.docker.com/compose/), you can set up a sample Dgraph cluster using this `docker-compose.yaml` configuration:
 
 ```yaml
 version: '3.5'
@@ -127,7 +124,7 @@ Before managing users and groups and configuring ACL rules, you will need to log
 
 ### Logging In
 
-To login, send a POST request to `/admin` with the GraphQL mutation. For example, to log in as the root user groot:
+To login, send a POST request to `/admin` with the GraphQL mutation. For example, to log in as the root user `groot`:
 
 ```graphql
 mutation {
@@ -197,8 +194,7 @@ mutation {
 
 ### Login using a client
 
-Now that the ACL settings are in place, to access the data protected by ACL rules, we need to
-first log in through a user. This is typically done via the client's `.login(USER_ID, USER_PASSWORD)` method.
+With ACL configured, you need to log in as a user to access data protected by ACL rules. You can do this using the client's `.login(USER_ID, USER_PASSWORD)` method.
 
 Here are some code samples using a client:
 
@@ -231,7 +227,7 @@ curl http://localhost:8080/admin --silent --request POST \
 ```
 
 {{% notice "tip" %}}
-As parsing JSON results on the command line can be challenging, embedded in this snippet are some alternatives to extract the desired data using popular tools, such as [the silver searcher](https://github.com/ggreer/the_silver_searcher) or the json query tool [jq](https://stedolan.github.io/jq).
+Parsing JSON results on the command line can be challenging, so you will find some alternatives to extract the desired data using popular tools, such as [the silver searcher](https://github.com/ggreer/the_silver_searcher) or the json query tool [jq](https://stedolan.github.io/jq), embedded in this snippet.
 {{% /notice %}}
 
 ## User and group administration
@@ -360,7 +356,7 @@ mutation {
 
 ## ACL rules configuration
 
-You can set up ACL rules using Dgraph Ratel UI or by using a GraphQL tool, such as [Insomnia](https://insomnia.rest/), [GraphQL Playground](https://github.com/prisma/graphql-playground), [GraphiQL](https://github.com/skevy/graphiql-app), etc. The permissions can be set on a predicate for the group using using pattern similar to the UNIX file permission convention:
+You can set up ACL rules using the Dgraph Ratel UI or by using a GraphQL tool, such as [Insomnia](https://insomnia.rest/), [GraphQL Playground](https://github.com/prisma/graphql-playground), [GraphiQL](https://github.com/skevy/graphiql-app), etc. You can set the permissions on a predicate for the group using a pattern similar to the UNIX file permission conventions shown below:
 
 | Permission                  | Value | Binary |
 |-----------------------------|-------|--------|
@@ -448,7 +444,7 @@ mutation {
 
 ## Querying users and groups
 
-You can set up ACL rules using Dgraph Ratel UI or by using a GraphQL tool, such as [Insomnia](https://insomnia.rest/), [GraphQL Playground](https://github.com/prisma/graphql-playground), [GraphiQL](https://github.com/skevy/graphiql-app), etc. The permissions can be set on a predicate for the group using using pattern similar to the UNIX file permission convention:
+You can set up ACL rules using the Dgraph Ratel UI or by using a GraphQL tool, such as [Insomnia](https://insomnia.rest/), [GraphQL Playground](https://github.com/prisma/graphql-playground), [GraphiQL](https://github.com/skevy/graphiql-app), etc. The permissions can be set on a predicate for the group using using pattern similar to the UNIX file permission convention:
 
 You can query and get information for users and groups.  These sections show output that will show the user `alice` and the `dev` group along with rules for `friend` and `~friend` predicates.
 

--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -1,4 +1,4 @@
-password+++
++++
 date = "2017-03-20T22:25:17+11:00"
 title = "Access Control Lists"
 weight = 2
@@ -8,7 +8,7 @@ weight = 2
 
 {{% notice "note" %}}
 This feature was introduced in [v1.1.0](https://github.com/dgraph-io/dgraph/releases/tag/v1.1.0).
-The `dgrapch acl` command is deprecated and will be removed in a future release. ACL changes can be made by using the `/admin` GraphQL endpoint on any Alpha node.
+The `dgraph acl` command is deprecated and will be removed in a future release. ACL changes can be made by using the `/admin` GraphQL endpoint on any Alpha node.
 {{% /notice %}}
 
 Access Control List (ACL) provides access protection to your data stored in
@@ -37,7 +37,7 @@ make sure they are all using the same secret key file created in Step 2.
 In addition to command line flags `--acl_secret_file` and `--whitelist`, you can also configure Dgraph with a configuration file, e.g. `config.properties`, `config.yaml`, `config.json`, `config.toml`, `config.hcl`.  You can also use environment variables, i.e. `DGRAPH_ALPHA_ACL_SECRET_FILE` and `DGRAPH_ALPHA_WHITELIST`. See [Config]({{< relref "config" >}}) for more information in general about configuring Dgraph.
 {{% /notice %}}
 
-### Example of using Dgraph CLI
+### Example using Dgraph CLI
 
 Here is an example that starts a Dgraph Zero node and a Dgraph Alpha node with the ACL feature turned on.  You can run these commands in a separate terminal tab:
 
@@ -54,7 +54,7 @@ dgraph alpha --my=localhost:7080 --zero=localhost:5080 \
   --whitelist "10.0.0.0/8,172.0.0.0/8,192.168.0.0/16"
 ```
 
-### Example of using Docker Compose
+### Example using Docker Compose
 
 If you are using [Docker Compose](https://docs.docker.com/compose/), a sample cluster can be set up using this `docker-compose.yaml` configuration:
 
@@ -88,7 +88,7 @@ echo '12345678901234567890123456789012' > hmac_secret_file
 docker-compose up
 ```
 
-### Example of using Kubernetes Helm Chart
+### Example using Kubernetes Helm Chart
 
 If you deploy Dgraph on [Kubernetes](https://kubernetes.io/), you can configure the ACL feature using the [Dgraph Helm Chart](https://artifacthub.io/packages/helm/dgraph/dgraph).
 
@@ -237,8 +237,6 @@ As parsing JSON results on the command line can be challenging, embedded in this
 ## User and group administration
 
 The default configuration comes with a user `groot`, with a password of `password`.  The `groot` user is part of administrative group called `guardians` that have access to everything.  You can add more users to the `guardians` group as needed.
-
-The examples below will use the Dgraph endpoint `localhost:8080/admin` as a demo; make sure to choose the correct IP and port for your environment.
 
 ### Reset the root password
 
@@ -450,6 +448,10 @@ mutation {
 
 ## Querying users and groups
 
+You can set up ACL rules using Dgraph Ratel UI or by using a GraphQL tool, such as [Insomnia](https://insomnia.rest/), [GraphQL Playground](https://github.com/prisma/graphql-playground), [GraphiQL](https://github.com/skevy/graphiql-app), etc. The permissions can be set on a predicate for the group using using pattern similar to the UNIX file permission convention:
+
+You can query and get information for users and groups.  These sections show output that will show the user `alice` and the `dev` group along with rules for `friend` and `~friend` predicates.
+
 ### Query for users
 
 Let's query for the user `alice`:
@@ -556,7 +558,7 @@ group's ACL rules, e.g.
           },
           {
             "permission": 7,
-            "predicate": "name"
+            "predicate": "~friend"
           }
         ]
       }
@@ -604,7 +606,7 @@ group's ACL rules, e.g.
         },
         {
           "permission": 7,
-          "predicate": "name"
+          "predicate": "~friend"
         }
       ]
     }

--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -34,7 +34,7 @@ make sure they are all using the same secret key file created in Step 2.
    ```
 
 {{% notice "tip" %}}
-In addition to command line flags `--acl_secret_file` and `--whitelist`, you can also configure Dgraph with a configuration file, e.g. `config.toml`, `config.properties`, `config.hcl`, etc. You can also use environment variables, i.e. `DGRAPH_ALPHA_ACL_SECRET_FILE` and `DGRAPH_ALPHA_WHITELIST`. See [Config]({{< relref "config" >}}) for more information in general about configuring Dgraph.
+In addition to command line flags `--acl_secret_file` and `--whitelist`, you can also configure Dgraph with a configuration file, e.g. `config.properties`, `config.yaml`, `config.json`, `config.toml`, `config.hcl`.  You can also use environment variables, i.e. `DGRAPH_ALPHA_ACL_SECRET_FILE` and `DGRAPH_ALPHA_WHITELIST`. See [Config]({{< relref "config" >}}) for more information in general about configuring Dgraph.
 {{% /notice %}}
 
 ### Example of using Dgraph CLI

--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -75,7 +75,7 @@ services:
   zero1:
     command: dgraph zero --my=zero1:5080 --replicas 1 --idx 1
     container_name: zero1
-    image: dgraph/dgraph:v20.11.2
+    image: dgraph/dgraph:{{< version >}}
 ```
 
 You can run this with:


### PR DESCRIPTION
This is update for Enterprise ACL rules fixes 6 queries and other updates:

* fixed graphql queries
  * updated all queries to have consistent style
  * fixed removing rules as use of API was incorrect (example did not work)
  * fixed remove user from group as syntax did not parse
  * fixed add rule to alice user as syntax did not parse
  * fixed remove rule from group as syntax did not parse
  * fixed delete user as syntax did not parse
  * fixed delete group as syntax did not parse
  * updated check dev group (getGroup) to add implicit keyword `query`
* removed licensing info as out of scope for ACLs (should be in overview or other page)
* removed `dgraph acl` command line documentation
* updated enabling ACL section
  * added `whitelist` that is required to use ACLs
  * removed unnecessary flag options (less is more)
  * removed developer docker-compose section as this had customers compile a go tool to generated Dgraph develop docker-compose file.  This is only appropriate for those developing Dgraph, not customers.
  * added minimal docker-compose section.
  * added minimal kubernetes (helm chart) section.
* added logging in and placed this at the top as this is a requirement to manage ACLs and was difficult to find
  * revised 'access data using a client' to login using client.
    * used bullets to add emphasis for languages + code examples.
  * added much needed curl example for operators
* moved users and group administration to their own section
* updated permissions/rules content
  * moved intermixed content to its own section
  * removed documentation on `dgraph acl` command
  * added table for permissions, revised explanation
