### PR TITLE
 Docs (GraphQL): 21.03 feature documentation for multiple @id fields in a type

### DIFF
--- a/content/graphql/mutations/upsert.md
+++ b/content/graphql/mutations/upsert.md
@@ -1,0 +1,113 @@
++++
+title = "Upsert Mutations"
+description = "Upsert mutations allow you to perform `add` or `update` operations based on whether a particular ID exists in the database"
+weight = 2
+[menu.main]
+    parent = "graphql-mutations"
+    name = "Upsert"
++++
+
+Upsert mutations allow you to perform `add` or `update` operations based on whether a particular ID exists in the database. The IDs must be external IDs, defined using the `@id` directive in the schema.
+
+We use the following schema to demonstrate how upserts work in GraphQL:
+
+**Schema**
+```graphql
+type Author {
+	id: String! @id
+	name: String! @search(by: [hash])
+	dob: DateTime
+	posts: [Post] @hasInverse(field: author)
+}
+
+type Post {
+	postID: String! @id
+	title: String! @search(by: [term, fulltext])
+	text: String @search(by: [fulltext, term])
+    author: Author!
+	datePublished: DateTime
+}
+```
+
+Dgraph automatically generates input and return types in the schema for the add mutation, as shown below:
+
+```graphql
+addPost(input: [AddPostInput!]!): AddPostPayload
+
+input AddPostInput {
+  postID: String!
+  title: String!
+  text: String
+  author: AuthorRef!
+  datePublished: DateTime
+}
+```
+
+Suppose we want to update the `text` field of a post with the ID `mm2`. But we also want to create a new post with that ID in case it doesn't already exist. To do this, we use the `addPost` mutation, but with an additional input variable `upsert`.  
+
+This is a Boolean variable. Setting it to `true` will change the default behavior of an `add` operation to an upsert operation.
+
+It will perform an `update` mutation and carry out the changes you specify in your request if the particular ID exists. Otherwise, it will fall back to a default `add` operation and create a new `Post` with that ID and the details you provide.
+
+Setting `upsert` to `false` is the same as using a plain `add` operation—it'll either fail or succeed, depending on whether the ID exists or not.
+
+**Example**: Add mutation with `upsert` true:
+
+```graphql
+mutation($post: [AddPostInput!]!) {
+  addPost(input: $post, upsert: true) {
+    post {
+      postID
+      title
+      text
+      author {
+        id
+      }
+    }
+  }
+}
+```
+
+With variables:
+
+```json
+{
+	"post": 
+  {
+		"postID": "mm2",
+		"title": "Second Post",
+		"text": "This is my second post, and updated with some new information.",
+		"author": {
+			"id": "micky"
+		}
+	}
+}
+```
+
+If a post with the ID `mm2` exists, it will update the post with the new details. Otherwise, it'll create a new `Post` with that ID and the values you provided. In either case, you'll get the following response back:
+
+```graphql
+"data": {
+    "addPost": {
+      "post": [
+        {
+          "postID": "mm2",
+          "title": "Second Post",
+          "text": "This is my second post, and updated with some new information.",
+          "author": {
+            "id": "micky"
+          }
+        }
+      ]
+    }
+  }
+```
+
+{{% notice "note" %}}
+* The default value of `uspert` will be false, for backward compatibility.
+* Upsert operations are only relevant for types containing an `@id` field. Performing an `add` mutation with `upsert` set to `true` for a type that doesn't have any `@id` field will have no effect.
+* The current behavior of Add and Update mutations is such that they do not update deep level nodes. So Add mutations with `upsert` set to `true` will only update values at the root level. 
+{{% /notice %}}
+
+## Examples
+You can refer to the following [link](https://github.com/dgraph-io/dgraph/blob/master/graphql/resolve/add_mutation_test.yaml) for more examples.

--- a/content/graphql/schema/ids.md
+++ b/content/graphql/schema/ids.md
@@ -46,14 +46,42 @@ type User {
 
 Dgraph will then require a unique username when creating a new user --- it'll generate the input type for `addUser` with `username: String!` so you can't make an add mutation without setting a username, and when processing the mutation, Dgraph will ensure that the username isn't already set for another node of the `User` type.
 
-Identities created with `@id` are reusable - if you delete an existing user, you can reuse the username.
+Identities created with `@id` are reusable - if you delete an existing user, you can reuse the username. But like `ID` types, fields declared with `@id` are also immutable.
 
 Fields with the `@id` directive must have the type `String!`.
 
-As with `ID` types, Dgraph will generate queries and mutations so you'll also be able to query, update and delete by id.
+As with `ID` types, Dgraph generates queries and mutations so you can query, update and delete data in nodes, using the fields with the `@id` directive as references.
+
+It's possible to use the `@id` directive on more than one field in a type. For example, you can define a type like the following:
+
+```graphql
+type Book {
+    name: String! @id
+    isbn: String! @id
+    genre: String!
+    ...
+}
+```
+
+ You can then perform queries with filters containing multiple `@id` fields; the fields you specify will execute in the manner of an `and` operation. For example, for the above schema, you can send a `getBook` query like the following:
+
+```graphql
+query {
+  getBook(name: "The Metamorphosis", isbn: "9871165072") {
+    name
+    genre
+    ...
+  }
+}
+```
+
+This will yield a positive response if both the `name` **and** `isbn` match any data in the database.
+
+{{% notice "note" %}}
+If there are multiple fields with `@id`’s  in a type then all of them will be nullable. If a type has a single field defined with either `@id` or `ID` then that will be non-nullable. 
+{{% /notice %}}
+
 
 ### More to come
 
-We are currently considering allowing types other than `String` with `@id`, see [here](https://discuss.dgraph.io/t/id-with-type-int/10402)
-
-We are currently considering expanding uniqueness to include composite ids and multiple unique fields (e.g. [this](https://discuss.dgraph.io/t/support-multiple-unique-fields-in-dgraph-graphql/8512) issue).
+We are currently considering allowing types other than `String` with `@id`; see [here](https://discuss.dgraph.io/t/id-with-type-int/10402) for more information.

--- a/content/howto/upserts.md
+++ b/content/howto/upserts.md
@@ -46,11 +46,13 @@ in the `Assigned` object returned from the mutation.
    modify the account (using additional mutations) or perform queries on it in
 whichever way you wish.
 
-## Upsert Block
+## Upserts in DQL and GraphQL
 
-You can also use the `Upsert Block` to achieve the upsert procedure in a single
+You can also use the `Upsert Block` in DQL to achieve the upsert procedure in a single
  mutation. The request will contain both the query and the mutation as explained
 [here]({{< relref "mutations/upsert-block.md" >}}).
+
+In GraphQL, you can use the `upsert` input variable in an `add` mutation, as explained [here]({{< relref "graphql/mutations/upsert.md">}}).
 
 ## Conflicts
 


### PR DESCRIPTION
Documentation for using multiple `@id` fields in a type as per PR: https://github.com/dgraph-io/dgraph/pull/7235.
Fixes [DOC-170](https://dgraph.atlassian.net/browse/DOC-170).