### PR TITLE
Docs(Lambda): Use a better compose file for dgraph + lambda

### DIFF
--- a/content/graphql/lambda/server.md
+++ b/content/graphql/lambda/server.md
@@ -64,7 +64,7 @@ If you're using Docker, you need to add the `--graphql` superflag's `lambda-url`
 Next, you need to add the Dgraph Lambda server configuration, and map the JavaScript file that contains the code for lambda functions to the `/app/script/script.js` file. Remember to set the `DGRAPH_URL` environment variable to your Alpha server.
 
 
-Here's a complete Docker example that uses the base dgraph image and adds support to lambda server
+Here's a complete Docker example that uses the base Dgraph image and adds Lambda server support:
 
 ```yml
 services:

--- a/content/graphql/lambda/server.md
+++ b/content/graphql/lambda/server.md
@@ -64,26 +64,6 @@ If you're using Docker, you need to add the `--graphql_lambda_url` to your Alpha
 
 Next, you need to add the Dgraph Lambda server configuration, and map the JavaScript file that contains the code for lambda functions to the `/app/script/script.js` file. Remember to set the `DGRAPH_URL` environment variable to your Alpha server.
 
-For example:
-
-```yml
-  lambda:
-    image: dgraph/dgraph-lambda:latest
-    container_name: lambda
-    labels:
-      cluster: test
-    ports:
-      - 8686:8686
-    depends_on:
-      - alpha
-    environment:
-      DGRAPH_URL: http://alpha:8180
-    volumes:
-      - type: bind
-        source: ./script.js
-        target: /app/script/script.js
-        read_only: true
-```
 
 Here's a complete Docker example that uses the base dgraph image and adds support to lambda server
 
@@ -99,25 +79,16 @@ services:
       - "8000:8000"
     volumes:
       - "dgraph:/dgraph"
-    networks:
-      - "dgraph"
 
   dgraph_lambda:
     image: dgraph/dgraph-lambda:latest
     ports:
-      - 8686:8686
+      - "8686:8686"
     environment:
       DGRAPH_URL: http://dgraph:8080
-    networks:
-      - "dgraph"
     volumes:
-      - type: bind
-        source: ./gql/script.js
-        target: /app/script/script.js
-        read_only: true
+      - ./gql/script.js:/app/script/script.js:ro
 
 volumes:
-  dgraph:
-networks:
   dgraph:
 ```


### PR DESCRIPTION
This copose spec has several advantages over the current example like: 

- It uses the same draph image as all the other examples to start Dgraph alpha + zero 
- I've removed the (version) in the compose spec since that's not required anymore given the latest compose spec updates
- I'm using env variables to set the correct lambda URL instead of using custom arguments .


