### PR TITLE
Renaming slash.dgraph.io -> cloud.dgraph.io everywhere

### DIFF
--- a/content/clients/java.md
+++ b/content/clients/java.md
@@ -64,7 +64,7 @@ DgraphClient dgraphClient = new DgraphClient(stub1, stub2, stub3);
 
 ### Creating a Client for Slash GraphQL Endpoint
 
-If you want to connect to Dgraph running on your [Slash GraphQL](https://slash.dgraph.io) instance, then all you need is the URL of your Slash GraphQL endpoint and the API key. You can get a client using them as follows :
+If you want to connect to Dgraph running on your [Slash GraphQL](https://cloud.dgraph.io) instance, then all you need is the URL of your Slash GraphQL endpoint and the API key. You can get a client using them as follows :
 
 ```java
 DgraphStub stub = DgraphClient.clientStubFromSlashEndpoint("https://your-slash-instance.cloud.dgraph.io/graphql", "your-api-key");

--- a/content/deploy/overview.md
+++ b/content/deploy/overview.md
@@ -15,7 +15,7 @@ This section focuses exclusively on deployment and management for these self-man
 scenarios. To learn about fully-managed options that let you focus on
 building apps and websites, rather than managing infrastructure, see the 
 [Dgraph cloud services docs](https://dgraph.io/docs/slash-graphql/), or 
-[Try Slash GraphQL](https://slash.dgraph.io/).
+[Try Slash GraphQL](https://cloud.dgraph.io/).
 
 A Dgraph cluster consists of the following:
 

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -61,9 +61,9 @@ Dgraph Labs recommends running Dgraph on Linux for production use.
 
 ### Get started with fully-managed Dgraph
 
-You can [get started using Slash GraphQL today](https://slash.dgraph.io) with a
+You can [get started using Slash GraphQL today](https://cloud.dgraph.io) with a
 free trial. To use Dgraph Cloud, visit our [Pricing Page](https://dgraph.io/pricing) or 
-[Pricing Calculator](https://slash.dgraph.io/pricing-calculator/) to get an
+[Pricing Calculator](https://cloud.dgraph.io/pricing-calculator/) to get an
 estimate, or [contact us](https://dgraph.io/connect).
 
 ## Dgraph and GraphQL

--- a/content/graphql/todo-app-tutorial/deploy.md
+++ b/content/graphql/todo-app-tutorial/deploy.md
@@ -6,7 +6,7 @@ weight = 7
     parent = "todo-app-tutorial"
 +++
 
-Let's now deploy our fully functional app on Slash GraphQL [slash.dgraph.io](https://slash.dgraph.io).
+Let's now deploy our fully functional app on Slash GraphQL [cloud.dgraph.io](https://cloud.dgraph.io).
 
 ### Create a deployment
 


### PR DESCRIPTION
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
