### PR TITLE
chore(fix) - update config 

### DIFF
--- a/content/deploy/config.md
+++ b/content/deploy/config.md
@@ -10,12 +10,9 @@ weight = 3
 For a single server setup, recommended for new users, please see [Get Started]({{< relref "get-started/index.md" >}}) page.
 {{% /notice %}}
 
-The full set of dgraph's configuration options (along with brief descriptions)
-can be viewed by invoking `dgraph` with the `--help` flag. For example, to see
-the options available for `dgraph alpha`, run `dgraph alpha --help`.
+The list of the available subcommands can be viewed by invoking `dgraph --help`.  The full set of configuration options for the subcommand can be viewed by invoking `dgraph <subcommand> --help`, such as `dgraph zero --help`.
 
-The options can be configured in multiple ways (from highest precedence to
-lowest precedence):
+The options can be configured in multiple ways (from highest precedence to lowest precedence):
 
 - Using command line flags (as described in the help output).
 - Using environment variables.
@@ -30,22 +27,22 @@ could be set using environment vars or flags.
 
 ## Command line flags
 
-Dgraph will have global flags that apply to all commands and commands specific to a subcommand. Below is an example of using command line flags with `dgraph alpha`.
+Dgraph will have *global flags* that apply to all subcommands and flags specific to a subcommand. Below is an example of using command line flags with `dgraph alpha`.
 
 ```bash
 dgraph alpha --my=alpha.example.com:7080 --zero=zero.example.com:5080 \
-  --badger.compression zstd:1 \
-  --block_rate 10 \
-  --jaeger.collector=http://jaeger:14268 \
-  --tls_cacert /dgraph/tls/node.crt \
-  --tls_cert /dgraph/tls/client.dgraphuser.crt \
-  --tls_client_auth REQUIREANDVERIFY \
+  --badger.compression "zstd:1" \
+  --block_rate "10" \
+  --jaeger.collector "http://jaeger:14268" \
+  --tls_cacert "/dgraph/tls/node.crt" \
+  --tls_cert "/dgraph/tls/client.dgraphuser.crt" \
+  --tls_client_auth "REQUIREANDVERIFY" \
   --tls_internal_port_enabled \
-  --tls_key /dgraph/tls/client.dgraphuser.key \
-  --tls_node_cert /dgraph/tls/node.crt \
-  --tls_node_key /dgraph/tls/node.key \
+  --tls_key "/dgraph/tls/client.dgraphuser.key" \
+  --tls_node_cert "/dgraph/tls/node.crt" \
+  --tls_node_key "/dgraph/tls/node.key" \
   --tls_use_system_ca \
-  --whitelist 10.0.0.0/8,172.0.0.0/8,192.168.0.0/16
+  --whitelist "10.0.0.0/8,172.0.0.0/8,192.168.0.0/16"
 ```
 
 ## Environment variables
@@ -63,28 +60,25 @@ For command line flags with the dot `.` notation, you can use underscore `_` in 
 Below is an example of environment variables for `dgraph alpha`:
 
 ```bash
-DGRAPH_ALPHA_BADGER_COMPRESSION=zstd:1
-DGRAPH_ALPHA_BLOCK_RATE=10
-DGRAPH_ALPHA_CLIENT_AUTH=VERIFYIFGIVEN
-DGRAPH_ALPHA_JAEGER_COLLECTOR=http://jaeger:14268
-DGRAPH_ALPHA_TLS_CACERT=/dgraph/tls/ca.crt
-DGRAPH_ALPHA_TLS_CERT=/dgraph/tls/client.dgraphuser.crt
-DGRAPH_ALPHA_TLS_INTERNAL_PORT_ENABLED=true
-DGRAPH_ALPHA_TLS_KEY=/dgraph/tls/client.dgraphuser.key
-DGRAPH_ALPHA_TLS_NODE_CERT=/dgraph/tls/node.crt
-DGRAPH_ALPHA_TLS_NODE_KEY=/dgraph/tls/node.key
-DGRAPH_ALPHA_TLS_USE_SYSTEM_CA=true
-DGRAPH_ALPHA_WHITELIST=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16
+DGRAPH_ALPHA_BADGER_COMPRESSION="zstd:1"
+DGRAPH_ALPHA_BLOCK_RATE="10"
+DGRAPH_ALPHA_CLIENT_AUTH="VERIFYIFGIVEN"
+DGRAPH_ALPHA_JAEGER_COLLECTOR="http://jaeger:14268"
+DGRAPH_ALPHA_TLS_CACERT="/dgraph/tls/ca.crt"
+DGRAPH_ALPHA_TLS_CERT="/dgraph/tls/client.dgraphuser.crt"
+DGRAPH_ALPHA_TLS_INTERNAL_PORT_ENABLED="true"
+DGRAPH_ALPHA_TLS_KEY="/dgraph/tls/client.dgraphuser.key"
+DGRAPH_ALPHA_TLS_NODE_CERT="/dgraph/tls/node.crt"
+DGRAPH_ALPHA_TLS_NODE_KEY="/dgraph/tls/node.key"
+DGRAPH_ALPHA_TLS_USE_SYSTEM_CA="true"
+DGRAPH_ALPHA_WHITELIST="10.0.0.0/8,172.0.0.0/8,192.168.0.0/16"
 ```
 
 ## Configuration file
 
-A configuration file can be specified using the `--config` flag, or an
-environment variable, e.g. `dgraph alpha --config my_config.json` or
-`DGRAPH_ALPHA_CONFIG=my_config.json dgraph alpha`.
+A configuration file can be specified using the `--config` flag, or an environment variable, e.g. `dgraph alpha --config my_config.json` or `DGRAPH_ALPHA_CONFIG=my_config.json dgraph alpha`.
 
-The config file structure is just simple key/value pairs (mirroring the flag
-names).
+The config file structure is just simple key/value pairs (mirroring the flag names).
 
 Configuration file formats supported are [JSON](https://www.json.org/json-en.html), [TOML](https://toml.io/en/), [YAML](https://yaml.org/), [HCL](https://github.com/hashicorp/hcl), and [Java
 properties](https://en.wikipedia.org/wiki/.properties) (detected via file extension). The file extensions are `.json`, `.toml`,
@@ -169,7 +163,7 @@ whitelist: 10.0.0.0/8,172.0.0.0/8,192.168.0.0/16
 Example HCL config file (`config.hcl`):
 
 {{% notice "note" %}}
-Though that HCL supports hierarchical key to hash, this currently does not work.
+Though that HCL language itself supports hierarchical key to hash, this currently does not work.  Instead you will have to use the full flag name with the dot `.` included.
 {{% /notice %}}
 
 ```hcl

--- a/content/deploy/config.md
+++ b/content/deploy/config.md
@@ -10,9 +10,10 @@ weight = 3
 For a single server setup, recommended for new users, please see [Get Started]({{< relref "get-started/index.md" >}}) page.
 {{% /notice %}}
 
-The list of the available subcommands can be viewed by invoking `dgraph --help`.  The full set of configuration options for the subcommand can be viewed by invoking `dgraph <subcommand> --help`, such as `dgraph zero --help`.
+You can see the list of available subcommands with `dgraph --help`.  You can view the full set of configuration options for a given subcommand with `dgraph <subcommand> --help` (for example, `dgraph zero --help`).
 
-The options can be configured in multiple ways (from highest precedence to lowest precedence):
+You can configure options in multiple ways, which are listed below from highest precedence to lowest precedence:
+
 
 - Using command line flags (as described in the help output).
 - Using environment variables.
@@ -21,13 +22,13 @@ The options can be configured in multiple ways (from highest precedence to lowes
 If no configuration for an option is used, then the default value as described
 in the `--help` output applies.
 
-Multiple configuration methods can be used all at the same time,  e.g. a core
+You can use multiple configuration methods at the same time, so a core
 set of options could be set in a config file, and instance specific options
 could be set using environment vars or flags.
 
 ## Command line flags
 
-Dgraph will have *global flags* that apply to all subcommands and flags specific to a subcommand. Below is an example of using command line flags with `dgraph alpha`.
+Dgraph has *global flags* that apply to all subcommands and flags specific to a subcommand. Below is an example of using command line flags with `dgraph alpha`.
 
 ```bash
 dgraph alpha --my=alpha.example.com:7080 --zero=zero.example.com:5080 \
@@ -76,16 +77,14 @@ DGRAPH_ALPHA_WHITELIST="10.0.0.0/8,172.0.0.0/8,192.168.0.0/16"
 
 ## Configuration file
 
-A configuration file can be specified using the `--config` flag, or an environment variable, e.g. `dgraph alpha --config my_config.json` or `DGRAPH_ALPHA_CONFIG=my_config.json dgraph alpha`.
+A configuration file can be specified using the `--config` flag, or an environment variable, such as `dgraph alpha --config my_config.json` or `DGRAPH_ALPHA_CONFIG=my_config.json dgraph alpha`.
 
-The config file structure is just simple key/value pairs (mirroring the flag names).
+The config consists of a set of key/value pairs, where the keys mirror the flag names.
 
-Configuration file formats supported are [JSON](https://www.json.org/json-en.html), [TOML](https://toml.io/en/), [YAML](https://yaml.org/), [HCL](https://github.com/hashicorp/hcl), and [Java
-properties](https://en.wikipedia.org/wiki/.properties) (detected via file extension). The file extensions are `.json`, `.toml`,
-`.yml` or `.yaml`, `.hcl`, and `.properties` for each format.
+Dgraph supports several configuration file formats that it detects based on file extensions ([`.json`](https://www.json.org/json-en.html), [`.toml`](https://toml.io/en/), [`.yml`](https://yaml.org/) or [`.yaml`](https://yaml.org/), [`.hcl`](https://github.com/hashicorp/hcl), and [`.properties`](https://en.wikipedia.org/wiki/.properties)).
 
 {{% notice "tip" %}}
-For command line flags with the dot `.` notation, you can use the full name as the key, e.g `jaeger.collector`, or represent them hierarchically where the key `jaeger` points to a hash.  For flags in snake case or using underscores, `_`, e.g. `tls_cacert`, you cannot represent them hierarchically.  See language specific examples below for further information.
+For command-line flags with the dot (`.`) notation, you can use the full name as the key (such as `jaeger.collector`), or represent them hierarchically where the key (`jaeger`) points to a hash. For flags in snake case or using underscore (`_`) notation (such as `tls_cacert`), you cannot represent them hierarchically.  See language-specific examples below for further information.
 {{% /notice %}}
 
 ### JSON config file

--- a/content/deploy/config.md
+++ b/content/deploy/config.md
@@ -11,7 +11,7 @@ For a single server setup, recommended for new users, please see [Get Started]({
 {{% /notice %}}
 
 The full set of dgraph's configuration options (along with brief descriptions)
-can be viewed by invoking dgraph with the `--help` flag. For example, to see
+can be viewed by invoking `dgraph` with the `--help` flag. For example, to see
 the options available for `dgraph alpha`, run `dgraph alpha --help`.
 
 The options can be configured in multiple ways (from highest precedence to
@@ -24,70 +24,184 @@ lowest precedence):
 If no configuration for an option is used, then the default value as described
 in the `--help` output applies.
 
-Multiple configuration methods can be used all at the same time. E.g. a core
+Multiple configuration methods can be used all at the same time,  e.g. a core
 set of options could be set in a config file, and instance specific options
 could be set using environment vars or flags.
+
+## Command line flags
+
+Dgraph will have global flags that apply to all commands and commands specific to a subcommand. Below is an example of using command line flags with `dgraph alpha`.
+
+```bash
+dgraph alpha --my=alpha.example.com:7080 --zero=zero.example.com:5080 \
+  --badger.compression zstd:1 \
+  --block_rate 10 \
+  --jaeger.collector=http://jaeger:14268 \
+  --tls_cacert /dgraph/tls/node.crt \
+  --tls_cert /dgraph/tls/client.dgraphuser.crt \
+  --tls_client_auth REQUIREANDVERIFY \
+  --tls_internal_port_enabled \
+  --tls_key /dgraph/tls/client.dgraphuser.key \
+  --tls_node_cert /dgraph/tls/node.crt \
+  --tls_node_key /dgraph/tls/node.key \
+  --tls_use_system_ca \
+  --whitelist 10.0.0.0/8,172.0.0.0/8,192.168.0.0/16
+```
+
+## Environment variables
 
 The environment variable names mirror the flag names as seen in the `--help`
 output. They are the concatenation of `DGRAPH`, the subcommand invoked
 (`ALPHA`, `ZERO`, `LIVE`, or `BULK`), and then the name of the flag (in
-uppercase). For example, instead of using `dgraph alpha --lru_mb=8096`, you
-could use `DGRAPH_ALPHA_LRU_MB=8096 dgraph alpha`.
+uppercase). For example, instead of using `dgraph alpha --block_rate 10`, you
+could use `DGRAPH_ALPHA_BLOCK_RATE=10 dgraph alpha`.
 
-Configuration file formats supported are JSON, TOML, YAML, HCL, and Java
-properties (detected via file extension). The file extensions are .json, .toml,
-.yml or .yaml, .hcl, and .properties for each format.
+{{% notice "tip" %}}
+For command line flags with the dot `.` notation, you can use underscore `_` in the environment variable name.  Thus `dgraph zero --jaeger.collector` becomes `DGRAPH_ZERO_JAEGER_COLLECTOR`.
+{{% /notice %}}
+
+Below is an example of environment variables for `dgraph alpha`:
+
+```bash
+DGRAPH_ALPHA_BADGER_COMPRESSION=zstd:1
+DGRAPH_ALPHA_BLOCK_RATE=10
+DGRAPH_ALPHA_CLIENT_AUTH=VERIFYIFGIVEN
+DGRAPH_ALPHA_JAEGER_COLLECTOR=http://jaeger:14268
+DGRAPH_ALPHA_TLS_CACERT=/dgraph/tls/ca.crt
+DGRAPH_ALPHA_TLS_CERT=/dgraph/tls/client.dgraphuser.crt
+DGRAPH_ALPHA_TLS_INTERNAL_PORT_ENABLED=true
+DGRAPH_ALPHA_TLS_KEY=/dgraph/tls/client.dgraphuser.key
+DGRAPH_ALPHA_TLS_NODE_CERT=/dgraph/tls/node.crt
+DGRAPH_ALPHA_TLS_NODE_KEY=/dgraph/tls/node.key
+DGRAPH_ALPHA_TLS_USE_SYSTEM_CA=true
+DGRAPH_ALPHA_WHITELIST=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16
+```
+
+## Configuration file
 
 A configuration file can be specified using the `--config` flag, or an
-environment variable. E.g. `dgraph zero --config my_config.json` or
-`DGRAPH_ZERO_CONFIG=my_config.json dgraph zero`.
+environment variable, e.g. `dgraph alpha --config my_config.json` or
+`DGRAPH_ALPHA_CONFIG=my_config.json dgraph alpha`.
 
 The config file structure is just simple key/value pairs (mirroring the flag
 names).
 
-Example JSON config file (config.json):
+Configuration file formats supported are [JSON](https://www.json.org/json-en.html), [TOML](https://toml.io/en/), [YAML](https://yaml.org/), [HCL](https://github.com/hashicorp/hcl), and [Java
+properties](https://en.wikipedia.org/wiki/.properties) (detected via file extension). The file extensions are `.json`, `.toml`,
+`.yml` or `.yaml`, `.hcl`, and `.properties` for each format.
+
+{{% notice "tip" %}}
+For command line flags with the dot `.` notation, you can use the full name as the key, e.g `jaeger.collector`, or represent them hierarchically where the key `jaeger` points to a hash.  For flags in snake case or using underscores, `_`, e.g. `tls_cacert`, you cannot represent them hierarchically.  See language specific examples below for further information.
+{{% /notice %}}
+
+### JSON config file
+
+Example JSON config file (`config.json`):
 
 ```json
 {
-  "my": "localhost:7080",
-  "zero": "localhost:5080",
-  "postings": "/path/to/p",
-  "wal": "/path/to/w"
+  "block_rate": 10,
+  "badger": {
+    "compression": "zstd:1",
+  },
+  "jaeger": {
+    "collector": "http://jaeger:14268",
+  },
+  "tls_cacert": "/dgraph/tls/node.crt",
+  "tls_cert": "/dgraph/tls/client.dgraphuser.crt",
+  "tls_client_auth": "REQUIREANDVERIFY",
+  "tls_internal_port_enabled": true,
+  "tls_key": "/dgraph/tls/client.dgraphuser.key",
+  "tls_node_cert": "/dgraph/tls/node.crt",
+  "tls_node_key": "/dgraph/tls/node.key",
+  "tls_use_system_ca": true,
+  "whitelist": "10.0.0.0/8,172.0.0.0/8,192.168.0.0/16"
 }
 ```
 
-Example TOML config file (config.toml):
+### TOML config file
+
+
+Example TOML config file (`config.toml`):
 
 ```toml
-my = "localhost:7080"
-zero = "localhost:5080"
-postings = "/path/to/p"
-wal = "/path/to/w"
+block_rate = 10
+tls_cacert = '/dgraph/tls/node.crt'
+tls_cert = '/dgraph/tls/client.dgraphuser.crt'
+tls_client_auth = 'REQUIREANDVERIFY'
+tls_internal_port_enabled = true
+tls_key = '/dgraph/tls/client.dgraphuser.key'
+tls_node_cert = '/dgraph/tls/node.crt'
+tls_node_key = '/dgraph/tls/node.key'
+tls_use_system_ca = true
+whitelist = '10.0.0.0/8,172.0.0.0/8,192.168.0.0/16'
+
+[badger]
+compression = 'zstd:1'
+
+[jaeger]
+collector = 'http://jaeger:14268'
 ```
 
+### YAML config file
 
-Example YAML config file (config.yml):
+Example YAML config file (`config.yml`):
 
 ```yaml
-my: "localhost:7080"
-zero: "localhost:5080"
-postings: "/path/to/p"
-wal: "/path/to/w"
+badger:
+  compression: zstd:1
+block_rate: 10
+jaeger:
+  collector: http://jaeger:14268
+tls_cacert: /dgraph/tls/node.crt
+tls_cert: /dgraph/tls/client.dgraphuser.crt
+tls_client_auth: REQUIREANDVERIFY
+tls_internal_port_enabled: true
+tls_key: /dgraph/tls/client.dgraphuser.key
+tls_node_cert: /dgraph/tls/node.crt
+tls_node_key: /dgraph/tls/node.key
+tls_use_system_ca: true
+whitelist: 10.0.0.0/8,172.0.0.0/8,192.168.0.0/16
 ```
 
-Example HCL config file (config.hcl):
+### HCL config file
+
+Example HCL config file (`config.hcl`):
+
+{{% notice "note" %}}
+Though that HCL supports hierarchical key to hash, this currently does not work.
+{{% /notice %}}
 
 ```hcl
-my = "localhost:7080"
-zero = "localhost:5080"
-postings = "/path/to/p"
-wal = "/path/to/w"
+badger.compression        = "zstd:1"
+block_rate                = 10
+jaeger.collector          = "http://jaeger:14268"
+tls_cacert                = "/dgraph/tls/node.crt"
+tls_cert                  = "/dgraph/tls/client.dgraphuser.crt"
+tls_client_auth           = "REQUIREANDVERIFY"
+tls_internal_port_enabled = true
+tls_key                   = "/dgraph/tls/client.dgraphuser.key"
+tls_node_cert             = "/dgraph/tls/node.crt"
+tls_node_key              = "/dgraph/tls/node.key"
+tls_use_system_ca         = true
+whitelist                 = "10.0.0.0/8,172.0.0.0/8,192.168.0.0/16"
 ```
 
-Example Java properties config file (config.properties):
-```text
-my=localhost:7080
-zero=localhost:5080
-postings=/path/to/p
-wal=/path/to/w
+### Java properties config file
+
+Example Java properties config file (`config.properties`):
+
+```properties
+badger.compression=zstd:1
+block_rate=10
+jaeger.collector=http://jaeger:14268
+tls_cacert=/dgraph/tls/node.crt
+tls_cert=/dgraph/tls/client.dgraphuser.crt
+tls_client_auth=REQUIREANDVERIFY
+tls_internal_port_enabled=true
+tls_key=/dgraph/tls/client.dgraphuser.key
+tls_node_cert=/dgraph/tls/node.crt
+tls_node_key=/dgraph/tls/node.key
+tls_use_system_ca=true
+whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16
 ```


### PR DESCRIPTION
Configuration refresh.

* expanded examples for config file formats, environment vars, and command line flags.
   * config files have examples have string, boolean, int
   * config files have examples flat dot `.` notation to key:hash 
   * env vars have example with flag with a dot `.`
* specific flags chosen, so that update super-flags can be more easily compared
* put config file examples under their own heading so that navigation is easier (bulleted list on the right side)
* removed lru example, as that is deprecated

Not Goal
* v21.03.0 and super flags.  This will be a follow up PR, so that this commit can cherry-picked to earlier versions.