### PR TITLE
docs(graphql): Add authorization Bearer notes

### DIFF
--- a/content/graphql/authorization/authorization-overview.md
+++ b/content/graphql/authorization/authorization-overview.md
@@ -86,6 +86,17 @@ for RSA Signature with SHA-256 asymmetric cryptography (the JWT is signed with t
 
 Both cases expect the JWT to be in a header `X-My-App-Auth` and expect the JWT to contain custom claims object `"https://my.app.io/jwt/claims": { ... }` with the claims used in authorization rules.
 
+The value of the `X-My-App-Auth` header is expected to be in one of these two forms:
+1. Just the JWT token. For example:
+    ```txt
+    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJodHRwczovL215LmFwcC5pby9qd3QvY2xhaW1zIjp7fX0.Pjlxpf-3FhH61EtHBRo2g1amQPRi0pNwoLUooGbxIho
+    ```
+
+2. A Bearer token, e.g., a JWT prepended with `Bearer ` prefix (including space). For example:
+    ```txt
+    Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJodHRwczovL215LmFwcC5pby9qd3QvY2xhaW1zIjp7fX0.Pjlxpf-3FhH61EtHBRo2g1amQPRi0pNwoLUooGbxIho
+    ```
+
 {{% notice "note" %}}
 Authorization is in beta and some aspects may change - for example, it's possible that the method to specify the `header`, `key`, etc. will move into the /admin `updateGQLSchema` mutation that sets the schema. Some features are also in active improvement and development.
 {{% /notice %}}


### PR DESCRIPTION
Fixes DOC-190
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
