### PR TITLE
Docs (Superflags) document new flags and options added in 21.03 as part of a CLI Command Reference

### DIFF
--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -7,35 +7,39 @@ weight = 20
 
 The Dgraph command-line interface (CLI) is used to deploy and manage Dgraph. You
 use it in self-managed deployment scenarios such as running Dgraph on on-premises
-servers hosted on your physical infrastructure, or running Dgraph on your AWS,
-GCP, or Azure cloud infrastructure. 
+servers hosted on your physical infrastructure, or running Dgraph in the cloud
+on your AWS, GCP, or Azure infrastructure. 
 
-The Dgraph CLI consists of a variety of commands (such as `alpha` or `upgrade`),
-some of which are grouped together (such as `acl add` and `acl info`). You specify
-settings for these commands using flags. Some flags have been deprecated and replaced
-in release 21.03.
+Dgraph has a root command used throughout the Dgraph CLI: `dgraph`. This root
+command is supported by multiple commands (such as `alpha` or `update`), some of
+which also contain commands. For example, the `acl` command requires you to
+specify one of the following commands: `add`, `del`, `info` or `mod`. You specify
+settings for commands using flags. 
 
-## Dgraph CLI flag updates in 21.03
+## Dgraph CLI flag updates in release 21.03
 
-In previous Dgraph releases, multiple related flags are used in a command,
-causing some commands to be very long. Starting in release 21.03, fewer flags are 
-used for the most complex commands (`alpha`, `backup`, `bulk`,`debug`, `live` and
+Some flags have been deprecated and replaced in release 21.03. In previous Dgraph
+releases, multiple related flags are used in a command, causing some commands to
+be very long. Starting in release 21.03, fewer flags are  used for the most
+complex commands (`alpha`, `backup`, `bulk`,`debug`, `live` and
 `zero`). Instead, many of these flags contain one or more options that let you 
 define multiple settings in a semicolon-delimited list that's encapsulated in 
 double-quotes. So, the general syntax for flags that contain options is as follows: 
 
-`--<flagname> "option-a=value; option-b=value"`
+```ssh
+--<flagname> "option-a=value; option-b=value"`
+```
 
 For example, the following command that is valid in release 20.11 is no longer
 valid starting in release 21.03:
 
-```bash
+```ssh
 dgraph alpha --ludicrous_mode=true ludicrous_concurrency=16
 ```
 
 Instead, you would express this command as follows starting in release 21.03:
 
-```bash
+```ssh
 dgraph alpha --ludicrous "enabled=true; concurrency=16;"
 ```
 

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -48,6 +48,7 @@ are unchanged from release 21.03.
 | Old Flag | Old Type | New Flag and Options | New Type | Applies To |
 |---------:|:---------|---------:|:---------|:----:|
 | | | **`--badger`** | | | |
+| `max_retries` | int | `max-retries` | int |`alpha`|
 | `badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
 | | | (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
 | `badger.cache_mb` | string | `cache-mb` | string |`bulk`|
@@ -56,8 +57,6 @@ are unchanged from release 21.03.
 | `acl_secret_file` | string | `secret-file` | string |`alpha`|
 | `acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
 | `acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| | | **`--badger`** | | |
-| `max_retries` | int | `max-retries` | int |`alpha`|
 | | | **`--limit`** | | |
 | `mutations` | string | `mutations` | string |`alpha`|
 | | | **`--ludicrous`** | | |
@@ -85,7 +84,6 @@ are unchanged from release 21.03.
 | | | **`--telemetry`** | |
 | `telemetry` | bool | `reports` | bool |`alpha` and `zero`|
 | `enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`|
-| `tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | | | **`--tls`** | |
 | `tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`|

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -47,7 +47,7 @@ release 21.03.
 |---------:|:---------|---------:|:---------|:----:|
 | | | **`--badger`** | | | |
 | `badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
-| | | (new) `goroutines` | int |`alpha`, `bulk`, `backup`|
+| | | (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
 | `badger.cache_mb` | string | `cache-mb` | string |`bulk`|
 | `badger.cache_percentage` | string | `cache-percentage` | string |`bulk`|
 | | | **`--acl`** | | |

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -51,42 +51,41 @@ The following table maps Dgraph CLI flags from release v20.11 and earlier that
 have been replaced by superflags in release v21.03. Any flags not shown here
 are unchanged from release v21.03.
 
-<!-- TBD alphabetize by compound flag -->
 | Old flag | Old type | New flag and options | New type | Applies to | Note <!-- or example --> |
 |---------:|:---------|---------:|:---------|:----:|:----:|
+| | | **`--acl`** | | | [Access Control List]({{< relref "enterprise-features/access-control-lists.md" >}}) flags |
+| `--acl_secret_file` | string | `secret-file` | string |`alpha`|
+| `--acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| `--acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
 | | | **`--badger`** | | |  [Badger](https://dgraph.io/docs/badger) flags |
 | `--max_retries` | int | `max-retries` | int |`alpha`|
 | `--badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
 | `--badger.cache_mb` | string | `cache-mb` | string |`bulk`|
 | `--badger.cache_percentage` | string | `cache-percentage` | string |`bulk`|
 ||| (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
-| | | **`--acl`** | | | [Access Control List]({{< relref "enterprise-features/access-control-lists.md" >}}) flags |
-| `--acl_secret_file` | string | `secret-file` | string |`alpha`|
-| `--acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| `--acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| | | **`--ludicrous`** | | | [Ludicrous Mode]({{< relref "deploy/ludicrous-mode.md" >}}) flags  |
-| `--ludicrous_mode` | bool | `enabled` | bool |`alpha`|
-| `--ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
 | | | **`--graphql`** | | | [GraphQL]({{< relref "graphql/overview.md" >}}) flags  |
 | `--graphql_introspection` | bool | `introspection` | bool |`alpha`|
 | `--graphql_debug` | bool | `debug` | bool |`alpha`|
 | `--graphql_extensions` | bool | `extensions` | bool |`alpha`|
 | `--graphql_poll_interval` | time.Duration | `poll-interval` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
 | `--graphql_lambda_url` | string | `lambda-url` | string |`alpha`|
-| | | **`--raft`** | | | [Raft]({{< relref "design-concepts/raft.md" >}}) flags  |
-| `--pending_proposals` | int | `pending-proposals` | int |`alpha`|
-| `--idx` | int | `idx` | int |`alpha`, `zero`|
-| `--group` | int | `group` | int |`alpha`|
-| `--learner` | bool | `learner` | bool | `alpha`, `zero`| <!-- TBD remove -->
-| `--snapshot-after` | int | `snapshot-after` | bool |`alpha`|
-| | | **`--security`** | | | Security flags |
-| `--auth_token` | string | `token` | string |`alpha`|
-| `--whitelist` | string | `whitelist` | string |`alpha`|
 | | | **`--limit`** | | | Limit-setting flags for Dgraph Alpha  |
 | `--mutations` | string | `mutations` | string |`alpha`|
 | `--query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`|
 | `--normalize_node_limit` | int | `normalize-node` | int |`alpha`|
 | `--mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`|
+| | | **`--ludicrous`** | | | [Ludicrous Mode]({{< relref "deploy/ludicrous-mode.md" >}}) flags  |
+| `--ludicrous_mode` | bool | `enabled` | bool |`alpha`|
+| `--ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
+| | | **`--raft`** | | | [Raft]({{< relref "design-concepts/raft.md" >}}) flags  |
+| `--pending_proposals` | int | `pending-proposals` | int |`alpha`|
+| `--idx` | int | `idx` | int |`alpha`, `zero`|
+| `--group` | int | `group` | int |`alpha`|
+|  |  | (new)`learner` | bool | `alpha`, `zero`|
+| `--snapshot-after` | int | `snapshot-after` | bool |`alpha`|
+| | | **`--security`** | | | Security flags |
+| `--auth_token` | string | `token` | string |`alpha`|
+| `--whitelist` | string | `whitelist` | string |`alpha`|
 | | | **`--telemetry`** | | | Telemetry flags  |
 | `--telemetry` | bool | `reports` | bool |`alpha` and `zero`|
 | `--enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`|
@@ -144,21 +143,21 @@ The commands in these groups are shown in the following table:
 | Dgraph core      | [`zero`](#dgraph-zero) | Dgraph Zero management node commands |
 | Data loading     | [`bulk`](#dgraph-bulk) | Dgraph [Bulk Loader]({{< relref "deploy/fast-data-loading/bulk-loader.md" >}}) commands     |
 | Data loading     | [`live`](#dgraph-live) | Dgraph [Live Loader]({{< relref "deploy/fast-data-loading/live-loader.md" >}}) commands     |
-| Data loading     | [`restore`](#dgraph-restore) | Command used to restore backups created using Dgraph enterprise     |
-| Dgraph security  | [`acl`](#dgraph-acl) | Dgraph enterprise access control list ([ACL]({{< relref "enterprise-features/access-control-lists.md" >}})) commands |
-| Dgraph security  | [`audit`](#name-command) |      |
-| Dgraph security  | [`cert`](#name-command) |      |
-| Dgraph debug     | [`debug`](#name-command)    |      |
-| Dgraph debug     | [`debuginfo`](#name-command)    |      |
-| Dgraph tools     | [`completion`](#name-command)    |      |
-| Dgraph tools     | [`conv`](#name-command)    |      |
-| Dgraph tools     | [`decrypt`](#name-command)    |      |
-| Dgraph tools     | [`export_backup`](#name-command)    |      |
-| Dgraph tools     | [`increment`](#name-command)    |      |
-| Dgraph tools     | [`lsbackup`](#name-command)    |      |
-| Dgraph tools     | [`migrate`](#name-command)    |      |
-| Dgraph tools     | [`raftmigrate`](#name-command)    |      |
-| Dgraph tools     | [`upgrade`](#name-command)    |      |
+| Data loading     | [`restore`](#dgraph-restore) | Command used to restore backups created using Dgraph Enterprise Edition     |
+| Dgraph security  | [`acl`](#dgraph-acl) | Dgraph access control list ([ACL]({{< relref "enterprise-features/access-control-lists.md" >}})) commands |
+| Dgraph security  | [`audit`](#dgraph-audit) | Decrypt audit files     |
+| Dgraph security  | [`cert`](#dgraph-cert) | Configure TLS and manage TLS certificates     |
+| Dgraph debug     | [`debug`](#dgraph-debug)    | Used to debug issues with Dgraph     |
+| Dgraph debug     | [`debuginfo`](#dgraph-debuginfo)    | Generates information about the current node for use in debugging issues with Dgraph clusters   |
+| Dgraph tools     | [`completion`](#dgraph-completion)    | Generates shell completion scripts for `bash` and `zsh`     |
+| Dgraph tools     | [`conv`](#dgraph-conv)    | Converts geographic files into RDF so that they can be consumed by Dgraph    |
+| Dgraph tools     | [`decrypt`](#dgraph-decrypt)    | Decrypts an export file created by an encrypted Dgraph cluster     |
+| Dgraph tools     | [`export_backup`](#dgraph-export_backup)    | Converts a binary backup created using Dgraph Enterprise Edition into an exported folder.      |
+| Dgraph tools     | [`increment`](#dgraph-increment)    | Increments a counter transactionally to confirm that a Dgraph Alpha node can handle query and mutation requests |
+| Dgraph tools     | [`lsbackup`](#dgraph-lsbackup)    | Lists information on backups in a given location   |
+| Dgraph tools     | [`migrate`](#dgraph-migrate)    | Migrates data from a MySQL database to Dgraph |
+| Dgraph tools     | [`raftmigrate`](#dgraph-raftmigrate)    | Dgraph Raft migration tool     |
+| Dgraph tools     | [`upgrade`](#dgraph-upgrade)    | Upgrades Dgraph to a newer version     |
 
 ### `dgraph` root command
 
@@ -419,8 +418,9 @@ Use "dgraph zero [command] --help" for more information about a command.
 
 #### `dgraph bulk`
 
-This command is used to TBD. The following replicates the help listing shown when you run
-`dgraph bulk --help`:
+This command is used to bulk load data with the Dgraph
+[Bulk Loader]({{< relref "deploy/fast-data-loading/bulk-loader.md"  >}}) tool.
+The following replicates the help listing shown when you run `dgraph bulk --help`:
 
 ```
 Run Dgraph Bulk Loader 
@@ -484,8 +484,9 @@ Use "dgraph bulk [command] --help" for more information about a command.
 
 #### `dgraph live`
 
-This command is used to TBD. The following replicates the help listing shown when you run
-`dgraph live --help`:
+This command is used to load live data with the Dgraph
+[Live Loader]({{< relref "deploy/fast-data-loading/live-loader.md" >}}) tool. The
+following replicates the help listing shown when you run `dgraph live --help`:
 
 ```
 Run Dgraph Live Loader 
@@ -715,7 +716,8 @@ Use "dgraph cert [command] --help" for more information about a command.
 
 ### Dgraph debug commands
 
-TBD
+Dgraph debug commands provide support for debugging issues with Dgraph deployments.
+To learn more, see [Using the Debug Tool]({{< relref "howto/using-increment-tool.md" >}}).
 
 #### `dgraph debug`
 
@@ -782,7 +784,8 @@ Use "dgraph debuginfo [command] --help" for more information about a command.
 
 ### Dgraph tools commands
 
-TBD
+Dgraph tools provide a variety of tools to make it easier for you to deploy and
+manage Dgraph.
 
 #### `dgraph completion`
 
@@ -806,7 +809,8 @@ Use "dgraph completion [command] --help" for more information about a command.
 
 #### `dgraph conv`
 
-This command runs the Dgraph geographic file converter. The following replicates
+This command runs the Dgraph geographic file converter, which onverts geographic
+files into RDF so that they can be consumed by Dgraph. The following replicates
 the help listing shown when you run `dgraph conv --help`:
 
 ```
@@ -853,9 +857,9 @@ Use "dgraph decrypt [command] --help" for more information about a command.
 
 #### `dgraph export_backup`
 
-This command is used to convert a [binary backup](TBD) created using Dgraph Enterprise
-Edition into an exported folder. The following replicates key information from
-the help listing shown when you run `dgraph export_backup --help`:
+This command is used to convert a [binary backup]({{< relref "enterprise-features/binary-backups.md" >}})
+created using Dgraph Enterprise Edition into an exported folder. The following
+replicates key information from the help listing shown when you run `dgraph export_backup --help`:
 
 ```
 Usage:
@@ -885,7 +889,7 @@ Use "dgraph export_backup [command] --help" for more information about a command
 
 This command increments a counter transactionally, so that you can confirm that
 an Alpha node is able to handle both query and mutation requests. To learn more,
-see [Using the Increment Tool](TBD). 
+see [Using the Increment Tool]({{< relref "howto/using-increment-tool.md" >}}). 
 The following replicates the help listing shown when you run `dgraph increment --help`:
 
 ```

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -30,18 +30,18 @@ Some flags are deprecated and replaced in release v21.03. In previous Dgraph
 releases, multiple related flags often are used in a command, causing some 
 commands to be very long. Starting in release v21.03, Dgraph uses *superflags* 
 for the most complex commands: `alpha`, `backup`, `bulk`,`debug`, `live` and
-`zero`. Superflags are compound flags: they contain one or more options that let
+`zero`. A superflag is a compound flag; it includes one or more options that let
 you define multiple settings in a semicolon-delimited list. The general syntax
-for superflags is as follows: `--<flagname> option-a=value; option-b=value`
+for a superflag is as follows: `--<flagname> option-a=value; option-b=value`
 
-For example, the following command that is valid in release 20.11 is no longer
-valid starting in release 21.03:
+For example, the following command that is valid in release v20.11 is no longer
+valid starting in release v21.03:
 
 ```ssh
 dgraph alpha --ludicrous_mode=true ludicrous_concurrency=16
 ```
 
-Instead, you can express this command as follows starting in release 21.03:
+Instead, you can express this command as follows starting in release v21.03:
 
 ```ssh
 dgraph alpha --ludicrous enabled=true; concurrency=16;
@@ -809,7 +809,7 @@ Use "dgraph completion [command] --help" for more information about a command.
 
 #### `dgraph conv`
 
-This command runs the Dgraph geographic file converter, which onverts geographic
+This command runs the Dgraph geographic file converter, which converts geographic
 files into RDF so that they can be consumed by Dgraph. The following replicates
 the help listing shown when you run `dgraph conv --help`:
 

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -10,19 +10,27 @@ use it in self-managed deployment scenarios; such as running Dgraph on on-premis
 servers hosted on your physical infrastructure, or running Dgraph in the cloud
 on your AWS, GCP, or Azure infrastructure. 
 
-Dgraph has a root command used throughout the Dgraph CLI: `dgraph`. This root
-command is supported by multiple commands (such as `alpha` or `update`), some of
-which also contain commands. For example, the `acl` command requires you to
-specify one of the following commands: `add`, `del`, `info` or `mod`. You specify
-settings for commands using flags. 
+Dgraph has a root command used throughout its CLI: `dgraph`. The `dgraph` command
+is supported by multiple subcommands (such as `alpha` or `update`), some of which
+are also supported by their own subcommands. For example, the `dgraph acl`
+command requires you to specify one of its subcommands: `add`, `del`, `info` or
+`mod`. As with other CLIs, you provide command options using flags like `--help`
+or `--telemetry`. 
+
+{{% notice "Tip" %}}
+The term *command* is used instead of *subcommand* throughout this document, 
+except when clarifying relationships in the CLI command hierarchy. The
+term *command* is also used for combinations of commands and their subcommands,
+such as `dgraph alpha debug`. 
+{{% /notice %}}
 
 ## Dgraph CLI flag updates in release 21.03
 
 Some flags are deprecated and replaced in release v21.03. In previous Dgraph
 releases, multiple related flags are used in a command, causing some commands to
-be very long. Starting in release v21.03, compound flags are  used for the most
-complex subcommands (`alpha`, `backup`, `bulk`,`debug`, `live` and
-`zero`). Compound flags contain one or more options that let you define multiple
+be very long. Starting in release v21.03, compound flags (or *superflags*) are
+used for the most complex commands: `alpha`, `backup`, `bulk`,`debug`, `live` and
+`zero`. Compound flags contain one or more options that let you define multiple
 settings in a semicolon-delimited list. The general syntax for compound flags
 is as follows: `--<flagname> option-a=value; option-b=value`
 
@@ -45,7 +53,7 @@ have been replaced by compound flags in release v21.03. Any flags not shown here
 are unchanged from release 21.03.
 
 <!-- TBD alphabetize by compound flag -->
-| Old Flag | Old Type | New Flag and Options | New Type | Applies To |
+| Old Flag | Old Type | New Flag and Options | New Type | Applies To | 
 |---------:|:---------|---------:|:---------|:----:|
 | | | **`--badger`** | | | |
 | `max_retries` | int | `max-retries` | int |`alpha`|
@@ -106,8 +114,11 @@ are unchanged from release 21.03.
 | `vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
 | `vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
 
+To learn more about each of these flags, see the `--help` output the subcommands of `dgraph`
+in the following section.
+
 <!--
-## Dgraph CLI commands
+## Dgraph CLI command help
 
 The Dgraph CLI includes the following commands (subcommands of `dgraph`). 
 CLI help for these commands is replicated inline below for your reference, or you
@@ -115,11 +126,24 @@ can find help by calling these commands with the `--help` flag.
 
 | Command    | Notes                    | Learn More |
 |------------|--------------------------|------------|
-|[`acl`](#name-command)| Notes | []() |
-|[`name`](#name-command)|  |
-|[`name`](#name-command)|  |
-|[`name`](#name-command)|  |
-|[`name`](#name-command)|  |
-|[`name`](#name-command)|  |
-|[`name`](#name-command)|  |
+|[`acl`](#name-command)| Dgraph Enterprise Edition access control list (ACL) tool | [Access Control Lists]({{< relref "enterprise-features/access-control-lists.md" >}}) |
+|[`alpha`](#name-command)|  |
+|[`audit`](#name-command)|  |
+|[`bulk`](#name-command)|  |
+|[`cert`](#name-command)|  |
+|[`completion`](#name-command)|  |
+|[`conv`](#name-command)|  |
+|[`debug`](#name-command)|  |
+|[`debuginfo`](#name-command)|  |
+|[`decrypt`](#name-command)|  |
+|[`dgraph`](#name-command)|  |
+|[`export_backup`](#name-command)|  |
+|[`increment`](#name-command)|  |
+|[`live`](#name-command)|  |
+|[`lsbackup`](#name-command)|  |
+|[`migrate`](#name-command)|  |
+|[`raftmigrate`](#name-command)|  |
+|[`restore`](#name-command)|  |
+|[`upgrade`](#name-command)|  |
+|[`zero`](#name-command)|  |
 -->

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -1,0 +1,99 @@
++++
+title = "Dgraph CLI Command Reference"
+weight = 20
+[menu.main]
+    parent = "deploy"
++++
+
+The Dgraph command-line interface (CLI) is used to deploy and manage Dgraph. You
+use it in self-managed deployment scenarios such as running Dgraph on on-premises
+servers hosted on your physical infrastructure, or running Dgraph on your AWS,
+GCP, or Azure cloud infrastructure. 
+
+The Dgraph CLI consists of a variety of commands (such as `alpha` or `upgrade`),
+some of which are grouped together (such as `acl add` and `acl info`). You specify
+settings for these commands using flags. Some flags have been deprecated and replaced
+in release 21.03.
+
+## Dgraph CLI flag updates in 21.03
+
+In previous Dgraph releases, multiple related flags are used in a command,
+causing some commands to be very long. Starting in release 21.03, fewer flags are 
+used for the most complex commands (`alpha`, `backup`, `bulk`,`debug`, `live` and
+`zero`). Instead, many of these flags contain one or more options that let you 
+define multiple settings in a semicolon-delimited list that's encapsulated in 
+double-quotes. So, the general syntax for flags that contain options is as follows: 
+
+`--<flagname> "option-a=value; option-b=value"`
+
+For example, the following command that is valid in release 20.11 is no longer
+valid starting in release 21.03:
+
+```bash
+dgraph alpha --ludicrous_mode=true ludicrous_concurrency=16
+```
+
+Instead, you would express this command as follows starting in release 21.03:
+
+```bash
+dgraph alpha --ludicrous "enabled=true; concurrency=16;"
+```
+
+The following table maps Dgraph CLI flags from release 20.11 and earlier to new
+flags used starting in release 21.03; any flags not shown here are unchanged from
+release 21.03.
+
+| Old Flag | Old Type | New Flag and Options | New Type | Applies To |
+|---------:|:---------|---------:|:---------|:----:|
+| | | **`--badger`** | | | |
+| `badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
+| | | (new) `goroutines` | int |`alpha`, `bulk`, `backup`|
+| `badger.cache_mb` | string | `cache-mb` | string |`bulk`|
+| `badger.cache_percentage` | string | `cache-percentage` | string |`bulk`|
+| | | **`--acl`** | | |
+| `acl_secret_file` | string | `secret-file` | string |`alpha`|
+| `acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| `acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| | | **`--ludicrous`** | | |
+| `ludicrous_mode` | bool | `enabled` | bool |`alpha`|
+| `ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
+| | | **`--graphql`** | | 
+| `graphql_introspection` | bool | `introspection` | bool |`alpha`|
+| `graphql_debug` | bool | `debug` | bool |`alpha`|
+| `graphql_extensions` | bool | `extensions` | bool |`alpha`|
+| `graphql_poll_interval` | time.Duration | `poll-interval` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| `graphql_lambda_url` | string | `lambda-url` | string |`alpha`|
+| | | **`--raft`** | |
+| `pending_proposals` | int | `pending-proposals` | int |`alpha`|
+| `idx` | int | `idx` | int |`alpha`, `zero`|
+| `group` | int | `group` | int |`alpha`|
+| `learner` | bool | `learner` | bool | `alpha`, `zero`|
+| `snapshot-after` | int | `snapshot-after` | bool |`alpha`|
+| | | **`--security`** | | 
+| `auth_token` | string | `token` | string |`alpha`|
+| `whitelist` | string | `whitelist` | string |`alpha`|
+| | | **`--limit`** | | 
+| `query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`|
+| `normalize_node_limit` | int | `normalize-node` | int |`alpha`|
+| `mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`|
+| | | **`--tls`** | |
+| `tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `tls_server_name` | string | `server-name` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `tls_client_auth` | string | `client-auth-type` | string |`alpha`, `zero`|
+| `tls_node_cert` | string | `server-cert` | string |`alpha`, `zero`|
+| `tls_node_key` | string | `server-key` | string |`alpha`, `zero`|
+| `tls_internal_port_enabled` | bool | `internal-port` | bool | `alpha`, `zero`, `bulk`, `backup`, `live`|
+| `tls_cert` | string | `client-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `tls_key` | string | `client-key` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| | | **`--trace`** | |
+| `trace` | float64 | `ratio` | float64 |`alpha`, `zero`|
+| `jaeger.collector` | string | `jaeger` | string | `alpha`, `zero`|
+| `datadog.collector` | string | `datadog` | string | `alpha`, `zero`|
+| | | **`--vault`** | |
+| `vault_addr` | string | `addr` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| `vault_roleid_file` | string | `role-id-file` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| `vault_secretid_file` | string | `secret-id-file` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
+| `vault_path` | string | `path` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| `vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
+| `vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -55,62 +55,62 @@ are unchanged from release v21.03.
 | Old flag | Old type | New flag and options | New type | Applies to | Note <!-- or example --> |
 |---------:|:---------|---------:|:---------|:----:|:----:|
 | | | **`--badger`** | | |  [Badger](https://dgraph.io/docs/badger) flags |
-| `max_retries` | int | `max-retries` | int |`alpha`|
-| `badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
-| `badger.cache_mb` | string | `cache-mb` | string |`bulk`|
-| `badger.cache_percentage` | string | `cache-percentage` | string |`bulk`|
-| (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
+| `--max_retries` | int | `max-retries` | int |`alpha`|
+| `--badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
+| `--badger.cache_mb` | string | `cache-mb` | string |`bulk`|
+| `--badger.cache_percentage` | string | `cache-percentage` | string |`bulk`|
+||| (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
 | | | **`--acl`** | | | [Access Control List]({{< relref "enterprise-features/access-control-lists.md" >}}) flags |
-| `acl_secret_file` | string | `secret-file` | string |`alpha`|
-| `acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| `acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| `--acl_secret_file` | string | `secret-file` | string |`alpha`|
+| `--acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| `--acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
 | | | **`--ludicrous`** | | | [Ludicrous Mode]({{< relref "deploy/ludicrous-mode.md" >}}) flags  |
-| `ludicrous_mode` | bool | `enabled` | bool |`alpha`|
-| `ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
+| `--ludicrous_mode` | bool | `enabled` | bool |`alpha`|
+| `--ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
 | | | **`--graphql`** | | | [GraphQL]({{< relref "graphql/overview.md" >}}) flags  |
-| `graphql_introspection` | bool | `introspection` | bool |`alpha`|
-| `graphql_debug` | bool | `debug` | bool |`alpha`|
-| `graphql_extensions` | bool | `extensions` | bool |`alpha`|
-| `graphql_poll_interval` | time.Duration | `poll-interval` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| `graphql_lambda_url` | string | `lambda-url` | string |`alpha`|
+| `--graphql_introspection` | bool | `introspection` | bool |`alpha`|
+| `--graphql_debug` | bool | `debug` | bool |`alpha`|
+| `--graphql_extensions` | bool | `extensions` | bool |`alpha`|
+| `--graphql_poll_interval` | time.Duration | `poll-interval` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| `--graphql_lambda_url` | string | `lambda-url` | string |`alpha`|
 | | | **`--raft`** | | | [Raft]({{< relref "design-concepts/raft.md" >}}) flags  |
-| `pending_proposals` | int | `pending-proposals` | int |`alpha`|
-| `idx` | int | `idx` | int |`alpha`, `zero`|
-| `group` | int | `group` | int |`alpha`|
-| `learner` | bool | `learner` | bool | `alpha`, `zero`|
-| `snapshot-after` | int | `snapshot-after` | bool |`alpha`|
+| `--pending_proposals` | int | `pending-proposals` | int |`alpha`|
+| `--idx` | int | `idx` | int |`alpha`, `zero`|
+| `--group` | int | `group` | int |`alpha`|
+| `--learner` | bool | `learner` | bool | `alpha`, `zero`| <!-- TBD remove -->
+| `--snapshot-after` | int | `snapshot-after` | bool |`alpha`|
 | | | **`--security`** | | | Security flags |
-| `auth_token` | string | `token` | string |`alpha`|
-| `whitelist` | string | `whitelist` | string |`alpha`|
+| `--auth_token` | string | `token` | string |`alpha`|
+| `--whitelist` | string | `whitelist` | string |`alpha`|
 | | | **`--limit`** | | | Limit-setting flags for Dgraph Alpha  |
-| `mutations` | string | `mutations` | string |`alpha`|
-| `query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`|
-| `normalize_node_limit` | int | `normalize-node` | int |`alpha`|
-| `mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`|
+| `--mutations` | string | `mutations` | string |`alpha`|
+| `--query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`|
+| `--normalize_node_limit` | int | `normalize-node` | int |`alpha`|
+| `--mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`|
 | | | **`--telemetry`** | | | Telemetry flags  |
-| `telemetry` | bool | `reports` | bool |`alpha` and `zero`|
-| `enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`|
+| `--telemetry` | bool | `reports` | bool |`alpha` and `zero`|
+| `--enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`|
 | | | **`--tls`** | | | [TLS]({{< relref "deploy/tls-configuration.md" >}}) flags  |
-| `tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `tls_server_name` | string | `server-name` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `tls_client_auth` | string | `client-auth-type` | string |`alpha`, `zero`|
-| `tls_node_cert` | string | `server-cert` | string |`alpha` and `zero`|
-| `tls_node_key` | string | `server-key` | string |`alpha` and `zero`|
-| `tls_internal_port_enabled` | bool | `internal-port` | bool | `alpha`, `zero`, `bulk`, `backup`, `live`|
-| `tls_cert` | string | `client-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `tls_key` | string | `client-key` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `--tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `--tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `--tls_server_name` | string | `server-name` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `--tls_client_auth` | string | `client-auth-type` | string |`alpha`, `zero`|
+| `--tls_node_cert` | string | `server-cert` | string |`alpha` and `zero`|
+| `--tls_node_key` | string | `server-key` | string |`alpha` and `zero`|
+| `--tls_internal_port_enabled` | bool | `internal-port` | bool | `alpha`, `zero`, `bulk`, `backup`, `live`|
+| `--tls_cert` | string | `client-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
+| `--tls_key` | string | `client-key` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | | | **`--trace`** | | | [Tracing]({{< relref "deploy/tracing.md" >}}) flags  |
-| `trace` | float64 | `ratio` | float64 |`alpha`, `zero`|
-| `jaeger.collector` | string | `jaeger` | string | `alpha`, `zero`|
-| `datadog.collector` | string | `datadog` | string | `alpha`, `zero`|
+| `--trace` | float64 | `ratio` | float64 |`alpha`, `zero`|
+| `--jaeger.collector` | string | `jaeger` | string | `alpha`, `zero`|
+| `--datadog.collector` | string | `datadog` | string | `alpha`, `zero`|
 | | | **`--vault`** | | | Vault flags  |
-| `vault_addr` | string | `addr` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
-| `vault_roleid_file` | string | `role-id-file` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
-| `vault_secretid_file` | string | `secret-id-file` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
-| `vault_path` | string | `path` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
-| `vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
-| `vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| `--vault_addr` | string | `addr` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| `--vault_roleid_file` | string | `role-id-file` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| `--vault_secretid_file` | string | `secret-id-file` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
+| `--vault_path` | string | `path` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| `--vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
+| `--vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
 
 To learn more about each of these flags, see the `--help` output of the Dgraph
 CLI commands listed in the following section.

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -6,7 +6,7 @@ weight = 20
 +++
 
 The Dgraph command-line interface (CLI) is used to deploy and manage Dgraph. You
-use it in self-managed deployment scenarios such as running Dgraph on on-premises
+use it in self-managed deployment scenarios; such as running Dgraph on on-premises
 servers hosted on your physical infrastructure, or running Dgraph in the cloud
 on your AWS, GCP, or Azure infrastructure. 
 
@@ -18,17 +18,14 @@ settings for commands using flags.
 
 ## Dgraph CLI flag updates in release 21.03
 
-Some flags have been deprecated and replaced in release 21.03. In previous Dgraph
+Some flags are deprecated and replaced in release v21.03. In previous Dgraph
 releases, multiple related flags are used in a command, causing some commands to
-be very long. Starting in release 21.03, fewer flags are  used for the most
-complex commands (`alpha`, `backup`, `bulk`,`debug`, `live` and
-`zero`). Instead, many of these flags contain one or more options that let you 
-define multiple settings in a semicolon-delimited list that's encapsulated in 
-double-quotes. So, the general syntax for flags that contain options is as follows: 
+be very long. Starting in release v21.03, compound flags are  used for the most
+complex subcommands (`alpha`, `backup`, `bulk`,`debug`, `live` and
+`zero`). Compound flags contain one or more options that let you define multiple
+settings in a semicolon-delimited list. The general syntax for compound flags
+is as follows: `--<flagname> option-a=value; option-b=value`
 
-```ssh
---<flagname> "option-a=value; option-b=value"`
-```
 
 For example, the following command that is valid in release 20.11 is no longer
 valid starting in release 21.03:
@@ -40,13 +37,14 @@ dgraph alpha --ludicrous_mode=true ludicrous_concurrency=16
 Instead, you would express this command as follows starting in release 21.03:
 
 ```ssh
-dgraph alpha --ludicrous "enabled=true; concurrency=16;"
+dgraph alpha --ludicrous enabled=true; concurrency=16;
 ```
 
-The following table maps Dgraph CLI flags from release 20.11 and earlier to new
-flags used starting in release 21.03; any flags not shown here are unchanged from
-release 21.03.
+The following table maps Dgraph CLI flags from release 20.11 and earlier that
+have been replaced by compound flags in release v21.03. Any flags not shown here
+are unchanged from release 21.03.
 
+<!-- TBD alphabetize by compound flag -->
 | Old Flag | Old Type | New Flag and Options | New Type | Applies To |
 |---------:|:---------|---------:|:---------|:----:|
 | | | **`--badger`** | | | |
@@ -58,6 +56,10 @@ release 21.03.
 | `acl_secret_file` | string | `secret-file` | string |`alpha`|
 | `acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
 | `acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
+| | | **`--badger`** | | |
+| `max_retries` | int | `max-retries` | int |`alpha`|
+| | | **`--limit`** | | |
+| `mutations` | string | `mutations` | string |`alpha`|
 | | | **`--ludicrous`** | | |
 | `ludicrous_mode` | bool | `enabled` | bool |`alpha`|
 | `ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
@@ -80,13 +82,17 @@ release 21.03.
 | `query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`|
 | `normalize_node_limit` | int | `normalize-node` | int |`alpha`|
 | `mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`|
+| | | **`--telemetry`** | |
+| `telemetry` | bool | `reports` | bool |`alpha` and `zero`|
+| `enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`|
+| `tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | | | **`--tls`** | |
 | `tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_server_name` | string | `server-name` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_client_auth` | string | `client-auth-type` | string |`alpha`, `zero`|
-| `tls_node_cert` | string | `server-cert` | string |`alpha`, `zero`|
-| `tls_node_key` | string | `server-key` | string |`alpha`, `zero`|
+| `tls_node_cert` | string | `server-cert` | string |`alpha` and `zero`|
+| `tls_node_key` | string | `server-key` | string |`alpha` and `zero`|
 | `tls_internal_port_enabled` | bool | `internal-port` | bool | `alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_cert` | string | `client-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_key` | string | `client-key` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
@@ -101,3 +107,21 @@ release 21.03.
 | `vault_path` | string | `path` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
 | `vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
 | `vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+
+<!--
+## Dgraph CLI commands
+
+The Dgraph CLI includes the following commands (subcommands of `dgraph`). 
+CLI help for these commands is replicated inline below for your reference, or you
+can find help by calling these commands with the `--help` flag.
+
+| Command    | Notes                    | Learn More |
+|------------|--------------------------|------------|
+|[`acl`](#name-command)| Notes | []() |
+|[`name`](#name-command)|  |
+|[`name`](#name-command)|  |
+|[`name`](#name-command)|  |
+|[`name`](#name-command)|  |
+|[`name`](#name-command)|  |
+|[`name`](#name-command)|  |
+-->

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -24,16 +24,15 @@ term *command* is also used for combinations of commands and their subcommands,
 such as `dgraph alpha debug`. 
 {{% /notice %}}
 
-## Dgraph CLI flag updates in release 21.03
+## Dgraph CLI superflags in release v21.03
 
 Some flags are deprecated and replaced in release v21.03. In previous Dgraph
-releases, multiple related flags are used in a command, causing some commands to
-be very long. Starting in release v21.03, compound flags (or *superflags*) are
-used for the most complex commands: `alpha`, `backup`, `bulk`,`debug`, `live` and
-`zero`. Compound flags contain one or more options that let you define multiple
-settings in a semicolon-delimited list. The general syntax for compound flags
-is as follows: `--<flagname> option-a=value; option-b=value`
-
+releases, multiple related flags often are used in a command, causing some 
+commands to be very long. Starting in release v21.03, Dgraph uses *superflags* 
+for the most complex commands: `alpha`, `backup`, `bulk`,`debug`, `live` and
+`zero`. Superflags are compound flags: they contain one or more options that let
+you define multiple settings in a semicolon-delimited list. The general syntax
+for superflags is as follows: `--<flagname> option-a=value; option-b=value`
 
 For example, the following command that is valid in release 20.11 is no longer
 valid starting in release 21.03:
@@ -42,57 +41,56 @@ valid starting in release 21.03:
 dgraph alpha --ludicrous_mode=true ludicrous_concurrency=16
 ```
 
-Instead, you would express this command as follows starting in release 21.03:
+Instead, you can express this command as follows starting in release 21.03:
 
 ```ssh
 dgraph alpha --ludicrous enabled=true; concurrency=16;
 ```
 
-The following table maps Dgraph CLI flags from release 20.11 and earlier that
-have been replaced by compound flags in release v21.03. Any flags not shown here
-are unchanged from release 21.03.
+The following table maps Dgraph CLI flags from release v20.11 and earlier that
+have been replaced by superflags in release v21.03. Any flags not shown here
+are unchanged from release v21.03.
 
 <!-- TBD alphabetize by compound flag -->
-| Old Flag | Old Type | New Flag and Options | New Type | Applies To | 
-|---------:|:---------|---------:|:---------|:----:|
-| | | **`--badger`** | | | |
+| Old flag | Old type | New flag and options | New type | Applies to | Note <!-- or example --> |
+|---------:|:---------|---------:|:---------|:----:|:----:|
+| | | **`--badger`** | | |  [Badger](https://dgraph.io/docs/badger) flags |
 | `max_retries` | int | `max-retries` | int |`alpha`|
 | `badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
-| | | (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
 | `badger.cache_mb` | string | `cache-mb` | string |`bulk`|
 | `badger.cache_percentage` | string | `cache-percentage` | string |`bulk`|
-| | | **`--acl`** | | |
+| (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
+| | | **`--acl`** | | | [Access Control List]({{< relref "enterprise-features/access-control-lists.md" >}}) flags |
 | `acl_secret_file` | string | `secret-file` | string |`alpha`|
 | `acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
 | `acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| | | **`--limit`** | | |
-| `mutations` | string | `mutations` | string |`alpha`|
-| | | **`--ludicrous`** | | |
+| | | **`--ludicrous`** | | | [Ludicrous Mode]({{< relref "deploy/ludicrous-mode.md" >}}) flags  |
 | `ludicrous_mode` | bool | `enabled` | bool |`alpha`|
 | `ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
-| | | **`--graphql`** | | 
+| | | **`--graphql`** | | | [GraphQL]({{< relref "graphql/overview.md" >}}) flags  |
 | `graphql_introspection` | bool | `introspection` | bool |`alpha`|
 | `graphql_debug` | bool | `debug` | bool |`alpha`|
 | `graphql_extensions` | bool | `extensions` | bool |`alpha`|
 | `graphql_poll_interval` | time.Duration | `poll-interval` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
 | `graphql_lambda_url` | string | `lambda-url` | string |`alpha`|
-| | | **`--raft`** | |
+| | | **`--raft`** | | | [Raft]({{< relref "design-concepts/raft.md" >}}) flags  |
 | `pending_proposals` | int | `pending-proposals` | int |`alpha`|
 | `idx` | int | `idx` | int |`alpha`, `zero`|
 | `group` | int | `group` | int |`alpha`|
 | `learner` | bool | `learner` | bool | `alpha`, `zero`|
 | `snapshot-after` | int | `snapshot-after` | bool |`alpha`|
-| | | **`--security`** | | 
+| | | **`--security`** | | | Security flags |
 | `auth_token` | string | `token` | string |`alpha`|
 | `whitelist` | string | `whitelist` | string |`alpha`|
-| | | **`--limit`** | | 
+| | | **`--limit`** | | | Limit-setting flags for Dgraph Alpha  |
+| `mutations` | string | `mutations` | string |`alpha`|
 | `query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`|
 | `normalize_node_limit` | int | `normalize-node` | int |`alpha`|
 | `mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`|
-| | | **`--telemetry`** | |
+| | | **`--telemetry`** | | | Telemetry flags  |
 | `telemetry` | bool | `reports` | bool |`alpha` and `zero`|
 | `enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`|
-| | | **`--tls`** | |
+| | | **`--tls`** | | | [TLS]({{< relref "deploy/tls-configuration.md" >}}) flags  |
 | `tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_server_name` | string | `server-name` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
@@ -102,11 +100,11 @@ are unchanged from release 21.03.
 | `tls_internal_port_enabled` | bool | `internal-port` | bool | `alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_cert` | string | `client-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
 | `tls_key` | string | `client-key` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| | | **`--trace`** | |
+| | | **`--trace`** | | | [Tracing]({{< relref "deploy/tracing.md" >}}) flags  |
 | `trace` | float64 | `ratio` | float64 |`alpha`, `zero`|
 | `jaeger.collector` | string | `jaeger` | string | `alpha`, `zero`|
 | `datadog.collector` | string | `datadog` | string | `alpha`, `zero`|
-| | | **`--vault`** | |
+| | | **`--vault`** | | | Vault flags  |
 | `vault_addr` | string | `addr` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
 | `vault_roleid_file` | string | `role-id-file` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
 | `vault_secretid_file` | string | `secret-id-file` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
@@ -114,36 +112,906 @@ are unchanged from release 21.03.
 | `vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
 | `vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
 
-To learn more about each of these flags, see the `--help` output the subcommands of `dgraph`
-in the following section.
+To learn more about each of these flags, see the `--help` output of the Dgraph
+CLI commands listed in the following section.
 
-<!--
-## Dgraph CLI command help
+## Dgraph CLI command help listing
 
-The Dgraph CLI includes the following commands (subcommands of `dgraph`). 
-CLI help for these commands is replicated inline below for your reference, or you
-can find help by calling these commands with the `--help` flag.
+The Dgraph CLI includes the root `dgraph` command and its subcommands. The CLI
+help for these commands is replicated inline below for your reference, or you
+can find help by calling these commands (or their subcommands) using the `--help`
+flag.
 
-| Command    | Notes                    | Learn More |
-|------------|--------------------------|------------|
-|[`acl`](#name-command)| Dgraph Enterprise Edition access control list (ACL) tool | [Access Control Lists]({{< relref "enterprise-features/access-control-lists.md" >}}) |
-|[`alpha`](#name-command)|  |
-|[`audit`](#name-command)|  |
-|[`bulk`](#name-command)|  |
-|[`cert`](#name-command)|  |
-|[`completion`](#name-command)|  |
-|[`conv`](#name-command)|  |
-|[`debug`](#name-command)|  |
-|[`debuginfo`](#name-command)|  |
-|[`decrypt`](#name-command)|  |
-|[`dgraph`](#name-command)|  |
-|[`export_backup`](#name-command)|  |
-|[`increment`](#name-command)|  |
-|[`live`](#name-command)|  |
-|[`lsbackup`](#name-command)|  |
-|[`migrate`](#name-command)|  |
-|[`raftmigrate`](#name-command)|  |
-|[`restore`](#name-command)|  |
-|[`upgrade`](#name-command)|  |
-|[`zero`](#name-command)|  |
--->
+{{% notice "Note" %}}
+Although many of the commands listed below have subcommands, only `dgraph` and
+subcommands of `dgraph` are included in this listing. 
+{{% /notice %}}
+
+The Dgraph CLI has several commands, which are organized into the following groups:
+
+* [Dgraph core](#dgraph-core-commands)
+* [Data loading](#data-loading-commands)
+* [Dgraph security](#dgraph-security-commands)
+* [Dgraph debug](#dgraph-debug-commands)
+* [Dgraph tools](#dgraph-tools-commands)
+
+The commands in these groups are shown in the following table:
+
+|Group             | Command                        | Note                         | 
+|------------------|--------------------------------|------------------------------|
+| (root)           | [`dgraph`](#dgraph-root-command) | Root command for Dgraph CLI  |          
+| Dgraph core      | [`alpha`](#dgraph-alpha) | Dgraph Alpha database node commands |
+| Dgraph core      | [`zero`](#dgraph-zero) | Dgraph Zero management node commands |
+| Data loading     | [`bulk`](#dgraph-bulk) | Dgraph [Bulk Loader]({{< relref "deploy/fast-data-loading/bulk-loader.md" >}}) commands     |
+| Data loading     | [`live`](#dgraph-live) | Dgraph [Live Loader]({{< relref "deploy/fast-data-loading/live-loader.md" >}}) commands     |
+| Data loading     | [`restore`](#dgraph-restore) | Command used to restore backups created using Dgraph enterprise     |
+| Dgraph security  | [`acl`](#dgraph-acl) | Dgraph enterprise access control list ([ACL]({{< relref "enterprise-features/access-control-lists.md" >}})) commands |
+| Dgraph security  | [`audit`](#name-command) |      |
+| Dgraph security  | [`cert`](#name-command) |      |
+| Dgraph debug     | [`debug`](#name-command)    |      |
+| Dgraph debug     | [`debuginfo`](#name-command)    |      |
+| Dgraph tools     | [`completion`](#name-command)    |      |
+| Dgraph tools     | [`conv`](#name-command)    |      |
+| Dgraph tools     | [`decrypt`](#name-command)    |      |
+| Dgraph tools     | [`export_backup`](#name-command)    |      |
+| Dgraph tools     | [`increment`](#name-command)    |      |
+| Dgraph tools     | [`lsbackup`](#name-command)    |      |
+| Dgraph tools     | [`migrate`](#name-command)    |      |
+| Dgraph tools     | [`raftmigrate`](#name-command)    |      |
+| Dgraph tools     | [`upgrade`](#name-command)    |      |
+
+### `dgraph` root command
+
+This command is the root for all commands in the Dgraph CLI. Key information from
+the help listing for `dgraph --help` is shown below:
+
+```
+Dgraph is a horizontally scalable and distributed graph database,
+providing ACID transactions, consistent replication and linearizable reads.
+It's built from the ground up to perform for a rich set of queries. Being a native
+graph database, it tightly controls how the data is arranged on disk to optimize
+for query performance and throughput, reducing disk seeks and network calls in a
+cluster.
+
+Usage:
+  dgraph [command] 
+
+Generic:             
+ help          Help about any command        
+ version       Prints the dgraph version details 
+
+Available Commands:
+
+Dgraph Core:   
+  alpha         Run Dgraph Alpha database server                   
+  zero          Run Dgraph Zero management server 
+
+Data Loading:     
+  bulk          Run Dgraph Bulk Loader          
+  live          Run Dgraph Live Loader    
+  restore       Restore backup from Dgraph Enterprise Edition   
+
+Dgraph Security:  
+  acl           Run the Dgraph Enterprise Edition ACL tool  
+  audit         Dgraph audit tool  
+  cert          Dgraph TLS certificate management                
+
+Dgraph Debug:         
+  debug         Debug Dgraph instance 
+  debuginfo     Generate debug information on the current node            
+
+Dgraph Tools:       
+  completion    Generates shell completion scripts for bash or zsh 
+  conv          Dgraph Geo file converter   
+  decrypt       Run the Dgraph decryption tool 
+  export_backup Export data inside single full or incremental backup  
+  increment     Increment a counter transactionally  
+  lsbackup      List info on backups in a given location 
+  migrate       Run the Dgraph migration tool from a MySQL database to Dgraph 
+  raftmigrate   Run the Raft migration tool  
+  upgrade       Run the Dgraph upgrade tool  
+
+Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --bindall                          Use 0.0.0.0 instead of localhost to bind to all addresses on local machine. (default true)
+      --block_rate int                   Block profiling rate. Must be used along with block profile_mode
+      --config string                    Configuration file. Takes precedence over default values, but is overridden to values set with environment variables and flags.
+      --cwd string                       Change working directory to the path specified. The parent must exist.
+      --expose_trace                     Allow trace endpoint to be accessible from remote
+  -h, --help                             help for dgraph
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files
+      --profile_mode string              Enable profiling mode, one of [cpu, mem, mutex, block]
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+```
+
+### Dgraph core commands
+
+Dgraph core commands provide core deployment and management functionality
+for the Dgraph Alpha database nodes and Dgraph Zero management nodes in your
+deployment.
+
+#### `dgraph alpha`
+
+This command is used to configure and run the Dgraph Alpha database nodes in
+your deployment. The following replicates the help listing for `dgraph alpha --help`:
+
+
+```
+A Dgraph Alpha instance stores the data. Each Dgraph Alpha is responsible for
+storing and serving one data group. If multiple Alphas serve the same group,
+they form a Raft group and provide synchronous replication.
+
+Usage:
+ dgraph alpha [flags] 
+
+Flags:
+     --abort_older_than string      Abort any pending transactions older than this duration. The liveness of a transaction is determined by its last mutation. (default "5m")
+     --acl string                   [Enterprise Feature] ACL options
+                                        access-ttl=6h; The TTL for the access JWT.
+                                        refresh-ttl=30d; The TTL for the refresh JWT.
+                                        secret-file=; The file that stores the HMAC secret, which is used for signing the JWT and should have at least 32 ASCII characters. Required to enable ACLs.
+                                     (default "access-ttl=6h; refresh-ttl=30d; secret-file=;")
+     --audit string                 Audit options
+                                        compress=false; Enables the compression of old audit logs.
+                                        days=10; The number of days audit logs will be preserved.
+                                        encrypt-file=; The path to the key file to be used for audit log encryption.
+                                        output=; [stdout, /path/to/dir] This specifies where audit logs should be output to.
+                                         "stdout" is for standard output. You can also specify the directory where audit logs 
+                                         will be saved. When stdout is specified as output other fields will be ignored.
+                                        size=100; The audit log max size in MB after which it will be rolled over.
+                                    
+     --badger string                Badger options
+                                        compression=snappy; [none, zstd:level, snappy] Specifies the compression algorithm and
+                                         compression level (if applicable) for the postings directory."none" would disable 
+                                         compression, while "zstd:1" would set zstd compression at level 1.
+                                        goroutines=8; The number of goroutines to use in badger.Stream.
+                                     (default "compression=snappy; goroutines=8;")
+     --cache_mb int                 Total size of cache (in MB) to be used in Dgraph. (default 1024)
+     --cache_percentage string      Cache percentages summing up to 100 for various caches (FORMAT: PostingListCache,PstoreBlockCache,PstoreIndexCache,WAL). (default "0,65,35,0")
+     --cdc string                   Change Data Capture options
+                                        ca-cert=; The path to CA cert file for TLS encryption.
+                                        client-cert=; The path to client cert file for TLS encryption.
+                                        client-key=; The path to client key file for TLS encryption.
+                                        file=; The path where audit logs will be stored.
+                                        kafka=; A comma separated list of Kafka hosts.
+                                        sasl-password=; The SASL password for Kafka.
+                                        sasl-user=; The SASL username for Kafka.
+                                    
+     --custom_tokenizers string     Comma separated list of tokenizer plugins
+     --enable_sentry                Turn on/off sending crash events to Sentry. (default true)
+     --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+     --export string                Folder in which to store exports. (default "export")
+     --graphql string               GraphQL options
+                                        debug=false; Enables debug mode in GraphQL. This returns auth errors to clients, and we do not recommend turning it on for production.
+                                        extensions=true; Enables extensions in GraphQL response body.
+                                        introspection=true; Enables GraphQL schema introspection.
+                                        lambda-url=; The URL of a lambda server that implements custom GraphQL Javascript resolvers.
+                                        poll-interval=1s; The polling interval for GraphQL subscription.
+                                     (default "introspection=true; debug=false; extensions=true; poll-interval=1s; lambda-url=;")
+ -h, --help                         help for alpha
+     --limit string                 Limit options
+                                        mutations-nquad=1000000; The maximum number of nquads that can be inserted in a mutation request.
+                                        normalize-node=10000; The maximum number of nodes that can be returned in a query that uses the normalize directive.
+                                        query-edge=1000000; The maximum number of edges that can be returned in a query. This applies to shortest path and recursive queries.
+                                     (default "query-edge=1000000; normalize-node=10000; mutations-nquad=1000000;")
+     --ludicrous string             Ludicrous options
+                                        concurrency=2000; The number of concurrent threads to use in Ludicrous mode.
+                                        enabled=false; Run Dgraph in Ludicrous mode.
+                                     (default "enabled=false; concurrency=2000;")
+     --max_retries int              Commits to disk will give up after these number of retries to prevent locking the worker in a failed state. Use -1 to retry infinitely. (default -1)
+     --mutations string             Set mutation mode to allow, disallow, or strict. (default "allow")
+     --my string                    addr:port of this server, so other Dgraph servers can talk to this.
+ -o, --port_offset int              Value added to all listening port numbers. [Internal=7080, HTTP=8080, Grpc=9080]
+ -p, --postings string              Directory to store posting lists. (default "p")
+     --raft string                  Raft options
+                                        group=; Provides an optional Raft Group ID that this Alpha would indicate to Zero to join.
+                                        idx=; Provides an optional Raft ID that this Alpha would use to join Raft groups.
+                                        learner=false; Make this Alpha a "learner" node. In learner mode, this Alpha will not participate in Raft elections. This can be used to achieve a read-only replica.
+                                        pending-proposals=256; Number of pending mutation proposals. Useful for rate limiting.
+                                        snapshot-after=10000; Create a new Raft snapshot after N number of Raft entries. The lower this number, the more frequent snapshot creation will be.
+                                     (default "learner=false; snapshot-after=10000; pending-proposals=256; idx=; group=;")
+     --security string              Security options
+                                        token=; If set, all Admin requests to Dgraph will need to have this token. The token can be passed as follows: for HTTP requests, in the X-Dgraph-AuthToken header. For Grpc, in auth-token key in the context.
+                                        whitelist=; A comma separated list of IP addresses, IP ranges, CIDR blocks, or hostnames you wish to whitelist for performing admin actions (i.e., --security "whitelist=144.142.126.254,127.0.0.1:127.0.0.3,192.168.0.0/16,host.docker.internal").
+                                     (default "token=; whitelist=;")
+     --survive string               Choose between "process" or "filesystem".
+                                        If set to "process", there would be no data loss in case of process crash, but the behavior would be indeterministic in case of filesystem crash.
+                                        If set to "filesystem", blocking sync would be called after every write, hence guaranteeing no data loss in case of hard reboot.
+                                        Most users should be OK with choosing "process". (default "process")
+     --telemetry                    Send anonymous telemetry data to Dgraph devs. (default true)
+     --tls string                   TLS Server options
+                                        ca-cert=; The CA cert file used to verify server certificates. Required for enabling TLS.
+                                        client-auth-type=VERIFYIFGIVEN; The TLS client authentication method.
+                                        client-cert=; (Optional) The client Cert file which is needed to connect as a client with the other nodes in the cluster.
+                                        client-key=; (Optional) The private client Key file which is needed to connect as a client with the other nodes in the cluster.
+                                        internal-port=false; (Optional) Enable inter-node TLS encryption between cluster nodes.
+                                        server-cert=; The server Cert file which is needed to initiate the server in the cluster.
+                                        server-key=; The server Key file which is needed to initiate the server in the cluster.
+                                        use-system-ca=true; Includes System CA into CA Certs.
+                                     (default "use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false;")
+     --tmp string                   Directory to store temporary buffers. (default "t")
+     --trace string                 Trace options
+                                        datadog=; URL of Datadog to send OpenCensus traces. As of now, the trace exporter does not support annotation logs and discards them.
+                                        jaeger=; URL of Jaeger to send OpenCensus traces.
+                                        ratio=0.01; The ratio of queries to trace.
+                                     (default "ratio=0.01; jaeger=; datadog=;")
+     --vault string                 Vault options
+                                        addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                        field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                        format=base64; Vault field format: raw or base64.
+                                        path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                        role-id-file=; File containing Vault role-id used for approle auth.
+                                        secret-id-file=; File containing Vault secret-id used for approle auth.
+                                     (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+ -w, --wal string                   Directory to store raft write-ahead logs. (default "w")
+ -z, --zero string                  Comma separated list of Dgraph Zero addresses of the form IP_ADDRESS:PORT. (default "localhost:5080")
+
+Use "dgraph alpha [command] --help" for more information about a command.
+```
+
+#### `dgraph zero`
+
+This command is used to configure and run the Dgraph Zero management nodes in
+your deployment. The following replicates the help listing shown when you run
+`dgraph zero --help`:
+
+```
+
+A Dgraph Zero instance manages the Dgraph cluster.  Typically, a single Zero
+instance is sufficient for the cluster; however, one can run multiple Zero
+instances to achieve high-availability.
+
+Usage:
+ dgraph zero [flags] 
+
+Flags:
+     --audit string                  Audit options
+                                         compress=; Enables the compression of old audit logs.
+                                         days=; The number of days audit logs will be preserved.
+                                         encrypt-file=; The path to the key file to be used for audit log encryption.
+                                         output=; [stdout, /path/to/dir] This specifies where audit logs should be output to.
+                                           "stdout" is for standard output. You can also specify the directory where audit logs 
+                                           will be saved. When stdout is specified as output other fields will be ignored.
+                                         size=; The audit log max size in MB after which it will be rolled over.
+     --cache_mb int                  Total size of cache (in MB) to be used in Dgraph. (default 1024)
+     --enable_sentry                 Turn on/off sending crash events to Sentry. (default true)
+     --enterprise_license string     Path to the enterprise license file.
+ -h, --help                          help for zero
+     --my string                     addr:port of this server, so other Dgraph servers can talk to this.
+     --peer string                   Address of another dgraphzero server.
+ -o, --port_offset int               Value added to all listening port numbers. [Grpc=5080, HTTP=6080]
+     --raft string                   Raft options
+                                         idx=1; Provides an optional Raft ID that this Alpha would use to join Raft groups.
+                                         learner=false; Make this Zero a "learner" node. In learner mode, this Zero will not participate in Raft elections. This can be used to achieve a read-only replica.
+                                      (default "idx=1; learner=false;")
+     --rebalance_interval duration   Interval for trying a predicate move. (default 8m0s)
+     --replicas int                  How many Dgraph Alpha replicas to run per data shard group. The count includes the original shard. (default 1)
+     --survive string                Choose between "process" or "filesystem".
+                                         If set to "process", there would be no data loss in case of process crash, but the behavior would be indeterministic in case of filesystem crash.
+                                         If set to "filesystem", blocking sync would be called after every write, hence guaranteeing no data loss in case of hard reboot.
+                                         Most users should be OK with choosing "process". (default "process")
+     --telemetry                     Send anonymous telemetry data to Dgraph devs. (default true)
+     --tls string                    TLS Server options
+                                         ca-cert=; The CA cert file used to verify server certificates. Required for enabling TLS.
+                                         client-auth-type=VERIFYIFGIVEN; The TLS client authentication method.
+                                         client-cert=; (Optional) The client Cert file which is needed to connect as a client with the other nodes in the cluster.
+                                         client-key=; (Optional) The private client Key file which is needed to connect as a client with the other nodes in the cluster.
+                                         internal-port=false; (Optional) Enable inter-node TLS encryption between cluster nodes.
+                                         server-cert=; The server Cert file which is needed to initiate the server in the cluster.
+                                         server-key=; The server Key file which is needed to initiate the server in the cluster.
+                                         use-system-ca=true; Includes System CA into CA Certs.
+                                      (default "use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false;")
+     --trace string                  Trace options
+                                         datadog=; URL of Datadog to send OpenCensus traces. As of now, the trace exporter does not support annotation logs and discards them.
+                                         jaeger=; URL of Jaeger to send OpenCensus traces.
+                                         ratio=0.01; The ratio of queries to trace.
+                                      (default "ratio=0.01; jaeger=; datadog=;")
+ -w, --wal string                    Directory storing WAL. (default "zw")
+
+Use "dgraph zero [command] --help" for more information about a command.
+```
+
+### Data loading commands
+
+#### `dgraph bulk`
+
+This command is used to TBD. The following replicates the help listing shown when you run
+`dgraph bulk --help`:
+
+```
+Run Dgraph Bulk Loader 
+Usage:
+ dgraph bulk [flags] 
+
+Flags:
+     --badger string                Badger options
+                                        cache-mb=64; Total size of cache (in MB) per shard in the reducer.
+                                        cache-percentage=70,30; Cache percentages summing up to 100 for various caches. (FORMAT: BlockCacheSize,IndexCacheSize)
+                                        compression=snappy; Specifies the compression algorithm and compression level (if applicable) for the postings directory. "none" would disable compression, while "zstd:1" would set zstd compression at level 1.
+                                        goroutines=8; The number of goroutines to use in badger.Stream.
+                                     (default "compression=snappy; goroutines=8; cache_mb=64; cache_percentage=70,30;")
+     --cleanup_tmp                  Clean up the tmp directory after the loader finishes. Setting this to false allows the bulk loader can be re-run while skipping the map phase. (default true)
+     --custom_tokenizers string     Comma separated list of tokenizer plugins
+     --encrypted                    Flag to indicate whether schema and data files are encrypted. Must be specified with --encryption_key_file or vault option(s).
+     --encrypted_out                Flag to indicate whether to encrypt the output. Must be specified with --encryption_key_file or vault option(s).
+     --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+ -f, --files string                 Location of *.rdf(.gz) or *.json(.gz) file(s) to load.
+     --force-namespace uint         Namespace onto which to load the data. If not set, will preserve the namespace. (default 18446744073709551615)
+     --format string                Specify file format (rdf or json) instead of getting it from filename.
+ -g, --graphql_schema string        Location of the GraphQL schema file.
+ -h, --help                         help for bulk
+     --http string                  Address to serve http (pprof). (default "localhost:8080")
+     --ignore_errors                ignore line parsing errors in rdf files
+     --map_shards int               Number of map output shards. Must be greater than or equal to the number of reduce shards. Increasing allows more evenly sized reduce shards, at the expense of increased memory usage. (default 1)
+     --mapoutput_mb int             The estimated size of each map file output. Increasing this increases memory usage. (default 2048)
+     --new_uids                     Ignore UIDs in load files and assign new ones.
+ -j, --num_go_routines int          Number of worker threads to use. MORE THREADS LEAD TO HIGHER RAM USAGE. (default 3)
+     --out string                   Location to write the final dgraph data directories. (default "./out")
+     --partition_mb int             Pick a partition key every N megabytes of data. (default 4)
+     --reduce_shards int            Number of reduce shards. This determines the number of dgraph instances in the final cluster. Increasing this potentially decreases the reduce stage runtime by using more parallelism, but increases memory usage. (default 1)
+     --reducers int                 Number of reducers to run concurrently. Increasing this can improve performance, and must be less than or equal to the number of reduce shards. (default 1)
+     --replace_out                  Replace out directory and its contents if it exists.
+ -s, --schema string                Location of schema file.
+     --skip_map_phase               Skip the map phase (assumes that map output files already exist).
+     --store_xids                   Generate an xid edge for each node.
+     --tls string                   TLS Client options
+                                        ca-cert=; The CA cert file used to verify server certificates. Required for enabling TLS.
+                                        client-cert=; (Optional) The Cert file provided by the client to the server.
+                                        client-key=; (Optional) The private Key file provided by the clients to the server.
+                                        internal-port=false; (Optional) Enable inter-node TLS encryption between cluster nodes.
+                                        server-name=; Used to verify the server hostname.
+                                        use-system-ca=true; Includes System CA into CA Certs.
+                                     (default "use-system-ca=true; internal-port=false;")
+     --tmp string                   Temp directory used to use for on-disk scratch space. Requires free space proportional to the size of the RDF file and the amount of indexing used. (default "tmp")
+     --vault string                 Vault options
+                                        addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                        field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                        format=base64; Vault field format: raw or base64.
+                                        path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                        role-id-file=; File containing Vault role-id used for approle auth.
+                                        secret-id-file=; File containing Vault secret-id used for approle auth.
+                                     (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+     --version                      Prints the version of Dgraph Bulk Loader.
+     --xidmap string                Directory to store xid to uid mapping
+ -z, --zero string                  gRPC address for Dgraph zero (default "localhost:5080")
+
+Use "dgraph bulk [command] --help" for more information about a command.
+```
+
+#### `dgraph live`
+
+This command is used to TBD. The following replicates the help listing shown when you run
+`dgraph live --help`:
+
+```
+Run Dgraph Live Loader 
+Usage:
+ dgraph live [flags] 
+
+Flags:
+ -a, --alpha string                 Comma-separated list of Dgraph alpha gRPC server addresses (default "127.0.0.1:9080")
+ -t, --auth_token string            The auth token passed to the server for Alter operation of the schema file. If used with --slash_grpc_endpoint, then this should be set to the API token issuedby Slash GraphQL
+ -b, --batch int                    Number of N-Quads to send as part of a mutation. (default 1000)
+ -m, --bufferSize string            Buffer for each thread (default "100")
+ -c, --conc int                     Number of concurrent requests to make to Dgraph (default 10)
+     --creds string                 Various login credentials if login is required.
+                                     user defines the username to login.
+                                     password defines the password of the user.
+                                     namespace defines the namespace to log into.
+                                     Sample flag could look like --creds user=username;password=mypass;namespace=2
+     --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+ -f, --files string                 Location of *.rdf(.gz) or *.json(.gz) file(s) to load
+     --force-namespace int          Namespace onto which to load the data.This flag will be ignored when not logging into galaxy namespace.Only guardian of galaxy should use this for loading data into multiple namespaces.Setting it to negative value will preserve the namespace.
+     --format string                Specify file format (rdf or json) instead of getting it from filename
+ -h, --help                         help for live
+     --http string                  Address to serve http (pprof). (default "localhost:6060")
+     --ludicrous                    Run live loader in ludicrous mode (Should only be done when alpha is under ludicrous mode)
+     --new_uids                     Ignore UIDs in load files and assign new ones.
+ -s, --schema string                Location of schema file
+     --slash_grpc_endpoint string   Path to Slash GraphQL GRPC endpoint. If --slash_grpc_endpoint is set, all other TLS options and connection options will beignored
+     --tls string                   TLS Client options
+                                        ca-cert=; The CA cert file used to verify server certificates. Required for enabling TLS.
+                                        client-cert=; (Optional) The Cert file provided by the client to the server.
+                                        client-key=; (Optional) The private Key file provided by the clients to the server.
+                                        internal-port=false; (Optional) Enable inter-node TLS encryption between cluster nodes.
+                                        server-name=; Used to verify the server hostname.
+                                        use-system-ca=true; Includes System CA into CA Certs.
+                                     (default "use-system-ca=true; internal-port=false;")
+     --tmp string                   Directory to store temporary buffers. (default "t")
+ -U, --upsertPredicate string       run in upsertPredicate mode. the value would be used to store blank nodes as an xid
+ -C, --use_compression              Enable compression on connection to alpha server
+     --vault string                 Vault options
+                                        addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                        field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                        format=base64; Vault field format: raw or base64.
+                                        path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                        role-id-file=; File containing Vault role-id used for approle auth.
+                                        secret-id-file=; File containing Vault secret-id used for approle auth.
+                                     (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+     --verbose                      Run the live loader in verbose mode
+ -x, --xidmap string                Directory to store xid to uid mapping
+ -z, --zero string                  Dgraph zero gRPC server address (default "127.0.0.1:5080")
+
+Use "dgraph live [command] --help" for more information about a command.
+```
+
+
+#### `dgraph restore`
+
+This command loads objects from available backups. The following replicates the
+help listing shown when you run `dgraph restore --help`:
+
+```
+Restore loads objects created with the backup feature in Dgraph Enterprise Edition (EE).
+
+Backups are originated from HTTP at /admin/backup, then can be restored using CLI restore
+command. Restore is intended to be used with new Dgraph clusters in offline state.
+
+The --location flag indicates a source URI with Dgraph backup objects. This URI supports all
+the schemes used for backup.
+
+Source URI formats:
+ [scheme]://[host]/[path]?[args]
+ [scheme]:///[path]?[args]
+ /[path]?[args] (only for local or NFS)
+
+Source URI parts:
+ scheme - service handler, one of: "s3", "minio", "file"
+   host - remote address. ex: "dgraph.s3.amazonaws.com"
+   path - directory, bucket or container at target. ex: "/dgraph/backups/"
+   args - specific arguments that are ok to appear in logs.
+
+The --posting flag sets the posting list parent dir to store the loaded backup files.
+
+Using the --zero flag will use a Dgraph Zero address to update the start timestamp using
+the restored version. Otherwise, the timestamp must be manually updated through Zero's HTTP
+'assign' command.
+
+Dgraph backup creates a unique backup object for each node group, and restore will create
+a posting directory 'p' matching the backup group ID. Such that a backup file
+named '.../r32-g2.backup' will be loaded to posting dir 'p2'.
+
+Usage examples:
+
+# Restore from local dir or NFS mount:
+$ dgraph restore -p . -l /var/backups/dgraph
+
+# Restore from S3:
+$ dgraph restore -p /var/db/dgraph -l s3://s3.us-west-2.amazonaws.com/srfrog/dgraph
+
+# Restore from dir and update Ts:
+$ dgraph restore -p . -l /var/backups/dgraph -z localhost:5080
+
+    
+Usage:
+ dgraph restore [flags] 
+
+Flags:
+     --backup_id string             The ID of the backup series to restore. If empty, it will restore the latest series.
+ -b, --badger string                Badger options
+                                        compression=snappy; Specifies the compression algorithm and compression level (if applicable) for the postings directory. "none" would disable compression, while "zstd:1" would set zstd compression at level 1.
+                                        goroutines=8; The number of goroutines to use in badger.Stream.
+                                     (default "compression=snappy; goroutines=8;")
+     --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+     --force_zero                   If false, no connection to a zero in the cluster will be required. Keep in mind this requires you to manually update the timestamp and max uid when you start the cluster. The correct values are printed near the end of this command's output. (default true)
+ -h, --help                         help for restore
+ -l, --location string              Sets the source location URI (required).
+ -p, --postings string              Directory where posting lists are stored (required).
+     --tls string                   TLS Client options
+                                        ca-cert=; The CA cert file used to verify server certificates. Required for enabling TLS.
+                                        client-cert=; (Optional) The Cert file provided by the client to the server.
+                                        client-key=; (Optional) The private Key file provided by the clients to the server.
+                                        internal-port=false; (Optional) Enable inter-node TLS encryption between cluster nodes.
+                                        server-name=; Used to verify the server hostname.
+                                        use-system-ca=true; Includes System CA into CA Certs.
+                                     (default "use-system-ca=true; internal-port=false;")
+     --vault string                 Vault options
+                                        addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                        field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                        format=base64; Vault field format: raw or base64.
+                                        path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                        role-id-file=; File containing Vault role-id used for approle auth.
+                                        secret-id-file=; File containing Vault secret-id used for approle auth.
+                                     (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+ -z, --zero string                  gRPC address for Dgraph zero. ex: localhost:5080
+
+Use "dgraph restore [command] --help" for more information about a command.
+```
+
+
+### Dgraph security commands
+
+Dgraph security commands let you manage access control lists (ACLs), manage
+certificates, and audit database usage.
+
+#### `dgraph acl`
+
+This command runs the Dgraph Enterprise Edition ACL tool. The following replicates
+the help listing shown when you run `dgraph acl --help`:
+
+```
+Run the Dgraph Enterprise Edition ACL tool 
+Usage:
+ dgraph acl [command] 
+
+Available Commands: 
+ add         Run Dgraph acl tool to add a user or group
+ del         Run Dgraph acl tool to delete a user or group
+ info        Show info about a user or group
+ mod         Run Dgraph acl tool to modify a user's password, a user's group list, or agroup's predicate permissions
+
+Flags:
+ -a, --alpha string            Dgraph Alpha gRPC server address (default "127.0.0.1:9080")
+     --guardian-creds string   Login credentials for the guardian
+                                 user defines the username to login.
+                                 password defines the password of the user.
+                                 namespace defines the namespace to log into.
+                                 Sample flag could look like --guardian-creds user=username;password=mypass;namespace=2
+ -h, --help                    help for acl
+     --tls string              TLS Client options
+                                   ca-cert=; The CA cert file used to verify server certificates. Required for enabling TLS.
+                                   client-cert=; (Optional) The Cert file provided by the client to the server.
+                                   client-key=; (Optional) The private Key file provided by the clients to the server.
+                                   internal-port=false; (Optional) Enable inter-node TLS encryption between cluster nodes.
+                                   server-name=; Used to verify the server hostname.
+                                   use-system-ca=true; Includes System CA into CA Certs.
+                                (default "use-system-ca=true; internal-port=false;")
+
+Use "dgraph acl [command] --help" for more information about a command.
+```
+
+#### `dgraph audit`
+
+This command decrypts audit files. These files are created using the `--audit`
+when you run the `dgraph alpha` command. The following replicates the help listing
+shown when you run `dgraph audit --help`:
+
+```
+Dgraph audit tool 
+Usage:
+ dgraph audit [command] 
+
+Available Commands: 
+ decrypt     Run Dgraph Audit tool to decrypt audit files
+
+Flags:
+ -h, --help   help for audit
+
+Use "dgraph audit [command] --help" for more information about a command.
+```
+
+#### `dgraph cert`
+
+This command lets you manage TLS certificates. The following replicates the help
+listing shown when you run `dgraph cert --help`:
+
+```
+Dgraph TLS certificate management 
+Usage:
+ dgraph cert [flags]
+ dgraph cert [command] 
+
+Available Commands: 
+ ls          lists certificates and keys
+
+Flags:
+ -k, --ca-key string           path to the CA private key (default "ca.key")
+ -c, --client string           create cert/key pair for a client name
+ -d, --dir string              directory containing TLS certs and keys (default "tls")
+     --duration int            duration of cert validity in days (default 365)
+ -e, --elliptic-curve string   ECDSA curve for private key. Values are: "P224", "P256", "P384", "P521".
+     --force                   overwrite any existing key and cert
+ -h, --help                    help for cert
+ -r, --keysize int             RSA key bit size for creating new keys (default 2048)
+ -n, --nodes strings           creates cert/key pair for nodes
+     --verify                  verify certs against root CA when creating (default true)
+
+Use "dgraph cert [command] --help" for more information about a command.
+```
+
+### Dgraph debug commands
+
+TBD
+
+#### `dgraph debug`
+
+This command is used to debug issues with a Dgraph database instance. The
+following replicates the help listing shown when you run `dgraph debug --help`:
+
+```
+Debug Dgraph instance 
+Usage:
+ dgraph debug [flags] 
+
+Flags:
+     --at uint                      Set read timestamp for all txns. (default 18446744073709551615)
+     --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+ -h, --help                         help for debug
+     --histogram                    Show a histogram of the key and value sizes.
+ -y, --history                      Show all versions of a key.
+     --item                         Output item meta as well. Set to false for diffs. (default true)
+     --jepsen string                Disect Jepsen output. Can be linear/binary.
+ -l, --lookup string                Hex of key to lookup.
+     --nokeys                       Ignore key_. Only consider amount when calculating total.
+ -p, --postings string              Directory where posting lists are stored.
+ -r, --pred string                  Only output specified predicate.
+     --prefix string                Uses a hex prefix.
+ -o, --readonly                     Open in read only mode. (default true)
+     --rollup string                Hex of key to rollup.
+ -s, --snap string                  Set snapshot term,index,readts to this. Value must be comma-separated list containing the value for these vars in that order.
+ -t, --truncate uint                Remove data from Raft entries until but not including this index.
+     --vals                         Output values along with keys.
+     --vault string                 Vault options
+                                        addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                        field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                        format=base64; Vault field format: raw or base64.
+                                        path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                        role-id-file=; File containing Vault role-id used for approle auth.
+                                        secret-id-file=; File containing Vault secret-id used for approle auth.
+                                     (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+ -w, --wal string                   Directory where Raft write-ahead logs are stored.
+
+Use "dgraph debug [command] --help" for more information about a command.
+```
+
+#### `dgraph debuginfo`
+
+This command generates information about the current node that is useful for debugging. 
+The following replicates the help listing shown when you run `dgraph debuginfo --help`:
+
+```
+Generate debug information on the current node 
+Usage:
+ dgraph debuginfo [flags] 
+
+Flags:
+ -a, --alpha string       Address of running dgraph alpha. (default "localhost:8080")
+ -x, --archive            Whether to archive the generated report (default true)
+ -d, --directory string   Directory to write the debug info into.
+ -h, --help               help for debuginfo
+ -p, --profiles strings   List of pprof profiles to dump in the report. (default [goroutine,heap,threadcreate,block,mutex,profile,trace])
+ -s, --seconds uint32     Duration for time-based profile collection. (default 15)
+ -z, --zero string        Address of running dgraph zero.
+
+Use "dgraph debuginfo [command] --help" for more information about a command.
+```
+
+### Dgraph tools commands
+
+TBD
+
+#### `dgraph completion`
+
+This command generates shell completion scripts for `bash` and `zsh` CLIs. The
+following replicates the help listing shown when you run `dgraph completion --help`:
+
+```
+Generates shell completion scripts for bash or zsh 
+Usage:
+ dgraph completion [command] 
+
+Available Commands: 
+ bash        bash shell completion
+ zsh         zsh shell completion
+
+Flags:
+ -h, --help   help for completion
+
+Use "dgraph completion [command] --help" for more information about a command.
+```
+
+#### `dgraph conv`
+
+This command runs the Dgraph geographic file converter. The following replicates
+the help listing shown when you run `dgraph conv --help`:
+
+```
+Dgraph Geo file converter 
+Usage:
+ dgraph conv [flags] 
+
+Flags:
+     --geo string       Location of geo file to convert
+     --geopred string   Predicate to use to store geometries (default "loc")
+ -h, --help             help for conv
+     --out string       Location of output rdf.gz file (default "output.rdf.gz")
+
+Use "dgraph conv [command] --help" for more information about a command.
+```
+
+#### `dgraph decrypt`
+
+This command lets you decrypt an export file created by an encrypted Dgraph
+cluster. The following replicates the help listing shown when you run
+`dgraph decrypt --help`:
+
+```
+A tool to decrypt an export file created by an encrypted Dgraph cluster 
+Usage:
+ dgraph decrypt [flags] 
+
+Flags:
+     --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+ -f, --file string                  Path to file to decrypt.
+ -h, --help                         help for decrypt
+ -o, --out string                   Path to the decrypted file.
+     --vault string                 Vault options
+                                        addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                        field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                        format=base64; Vault field format: raw or base64.
+                                        path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                        role-id-file=; File containing Vault role-id used for approle auth.
+                                        secret-id-file=; File containing Vault secret-id used for approle auth.
+                                     (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+
+Use "dgraph decrypt [command] --help" for more information about a command.
+```
+
+#### `dgraph export_backup`
+
+This command is used to convert a [binary backup](TBD) created using Dgraph Enterprise
+Edition into an exported folder. The following replicates key information from
+the help listing shown when you run `dgraph export_backup --help`:
+
+```
+Usage:
+  dgraph export_backup [flags] 
+
+Flags:
+  -d, --destination string           The folder to which export the backups.
+      --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+  -f, --format string                The format of the export output. Accepts a value of either rdf or json (default "rdf")
+  -h, --help                         help for export_backup
+  -l, --location string              Sets the location of the backup. Both file URIs and s3 are supported.
+                                     		This command will take care of all the full + incremental backups present in the location.
+      --vault string                 Vault options
+                                         addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                         field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                         format=base64; Vault field format: raw or base64.
+                                         path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                         role-id-file=; File containing Vault role-id used for approle auth.
+                                         secret-id-file=; File containing Vault secret-id used for approle auth.
+                                      (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+
+
+Use "dgraph export_backup [command] --help" for more information about a command.
+```
+
+#### `dgraph increment`
+
+This command increments a counter transactionally, so that you can confirm that
+an Alpha node is able to handle both query and mutation requests. To learn more,
+see [Using the Increment Tool](TBD). 
+The following replicates the help listing shown when you run `dgraph increment --help`:
+
+```
+Increment a counter transactionally 
+Usage:
+ dgraph increment [flags] 
+
+Flags:
+     --alpha string    Address of Dgraph Alpha. (default "localhost:9080")
+     --be              Best-effort. Read counter value without retrieving timestamp from Zero.
+     --creds string    Various login credentials if login is required.
+                         user defines the username to login.
+                         password defines the password of the user.
+                         namespace defines the namespace to log into.
+                         Sample flag could look like --creds user=username;password=mypass;namespace=2
+ -h, --help            help for increment
+     --jaeger string   Send opencensus traces to Jaeger.
+     --num int         How many times to run. (default 1)
+     --pred string     Predicate to use for storing the counter. (default "counter.val")
+     --retries int     How many times to retry setting up the connection. (default 10)
+     --ro              Read-only. Read the counter value without updating it.
+     --tls string      TLS Client options
+                           ca-cert=; The CA cert file used to verify server certificates. Required for enabling TLS.
+                           client-cert=; (Optional) The Cert file provided by the client to the server.
+                           client-key=; (Optional) The private Key file provided by the clients to the server.
+                           internal-port=false; (Optional) Enable inter-node TLS encryption between cluster nodes.
+                           server-name=; Used to verify the server hostname.
+                           use-system-ca=true; Includes System CA into CA Certs.
+                        (default "use-system-ca=true; internal-port=false;")
+     --wait duration   How long to wait.
+
+Use "dgraph increment [command] --help" for more information about a command.
+```
+
+#### `dgraph lsbackup`
+
+This command lists information on backups in a given location for Dgraph Enterprise
+Edition. To learn more, see [Backup List Tool]({{< relref "enterprise-features/lsbackup.md" >}}).
+The following replicates the help listing shown when you run `dgraph lsbackup --help`:
+
+```
+List info on backups in a given location 
+Usage:
+ dgraph lsbackup [flags] 
+
+Flags:
+ -h, --help              help for lsbackup
+ -l, --location string   Sets the source location URI (required).
+     --verbose           Outputs additional info in backup list.
+
+Use "dgraph lsbackup [command] --help" for more information about a command.
+```
+
+#### `dgraph migrate`
+
+This command runs the Dgraph migration tool to move data from a MySQL database to Dgraph. 
+The following replicates the help listing shown when you run `dgraph migrate --help`:
+
+```
+Run the Dgraph migration tool from a MySQL database to Dgraph 
+Usage:
+ dgraph migrate [flags] 
+
+Flags:
+     --db string              The database to import
+ -h, --help                   help for migrate
+     --host string            The hostname or IP address of the database server. (default "localhost")
+ -o, --output_data string     The data output file (default "sql.rdf")
+ -s, --output_schema string   The schema output file (default "schema.txt")
+     --password string        The password used for logging in
+     --port string            The port of the database server. (default "3306")
+ -q, --quiet                  Enable quiet mode to suppress the warning logs
+ -p, --separator string       The separator for constructing predicate names (default ".")
+     --tables string          The comma separated list of tables to import, an empty string means importing all tables in the database
+     --user string            The user for logging in
+
+Use "dgraph migrate [command] --help" for more information about a command.
+```
+
+#### `dgraph raftmigrate`
+
+This command runs the Dgraph Raft migration tool.<!-- TBD need to say more about this --> 
+The following replicates the help listing shown when you run `dgraph raftmigrate --help`:
+
+```
+Run the Raft migration tool 
+Usage:
+ dgraph raftmigrate [flags] 
+
+Flags:
+     --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
+ -h, --help                         help for raftmigrate
+     --new-dir string               Path to the new (z)w directory.
+     --old-dir string               Path to the old (z)w directory.
+     --vault string                 Vault options
+                                        addr=http://localhost:8200; Vault server address in the form of http://ip:port
+                                        field=enc_key; Vault kv store field whose value is the base64 encoded encryption key.
+                                        format=base64; Vault field format: raw or base64.
+                                        path=secret/data/dgraph; Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1.
+                                        role-id-file=; File containing Vault role-id used for approle auth.
+                                        secret-id-file=; File containing Vault secret-id used for approle auth.
+                                     (default "addr=http://localhost:8200; path=secret/data/dgraph; field=enc_key; format=base64; role-id-file=; secret-id-file=;")
+
+Use "dgraph raftmigrate [command] --help" for more information about a command.
+```
+
+#### `dgraph upgrade`
+
+This command helps you to upgrade from an earlier Dgraph release to a newer release. 
+The following replicates the help listing shown when you run `dgraph upgrade --help`:
+
+```
+This tool is supported only for the mainstream release versions of Dgraph, not for the beta releases. 
+Usage:
+ dgraph upgrade [flags] 
+
+Flags:
+     --acl               upgrade ACL from v1.2.2 to >=v20.03.0
+ -a, --alpha string      Dgraph Alpha gRPC server address (default "127.0.0.1:9080")
+ -d, --deleteOld         Delete the older ACL types/predicates (default true)
+     --dry-run           dry-run the upgrade
+ -f, --from string       The version string from which to upgrade, e.g.: v1.2.2
+ -h, --help              help for upgrade
+ -p, --password string   Password of ACL user
+ -t, --to string         The version string till which to upgrade, e.g.: v20.03.0
+ -u, --user string       Username of ACL user
+
+Use "dgraph upgrade [command] --help" for more information about a command.
+```

--- a/content/deploy/cli-command-ref.md
+++ b/content/deploy/cli-command-ref.md
@@ -17,7 +17,7 @@ command requires you to specify one of its subcommands: `add`, `del`, `info` or
 `mod`. As with other CLIs, you provide command options using flags like `--help`
 or `--telemetry`. 
 
-{{% notice "Tip" %}}
+{{% notice "tip" %}}
 The term *command* is used instead of *subcommand* throughout this document, 
 except when clarifying relationships in the CLI command hierarchy. The
 term *command* is also used for combinations of commands and their subcommands,
@@ -27,92 +27,105 @@ such as `dgraph alpha debug`.
 ## Dgraph CLI superflags in release v21.03
 
 Some flags are deprecated and replaced in release v21.03. In previous Dgraph
-releases, multiple related flags often are used in a command, causing some 
+releases, multiple related flags are often used in a command, causing some 
 commands to be very long. Starting in release v21.03, Dgraph uses *superflags* 
-for the most complex commands: `alpha`, `backup`, `bulk`,`debug`, `live` and
-`zero`. A superflag is a compound flag; it includes one or more options that let
-you define multiple settings in a semicolon-delimited list. The general syntax
-for a superflag is as follows: `--<flagname> option-a=value; option-b=value`
+for some flags used by the most complex commands: `alpha`, `backup`, `bulk`,
+`debug`, `live` and `zero`. Superflags are compound flags: they contain one or
+more options that let you define multiple settings in a semicolon-delimited list.
+The general syntax for superflags is as follows: `--<flagname> option-a=value; option-b=value`
 
-For example, the following command that is valid in release v20.11 is no longer
-valid starting in release v21.03:
+Release v21.03 includes the following superflags:
+* `--acl`
+* `--badger`
+* `--graphql`
+* `--limit`
+* `--ludicrous`
+* `--raft`
+* `--security`
+* `--telemetry`
+* `--tls`
+* `--trace`
+* `--vault`
+
+For example, the following command that is valid in release 20.11 is no longer
+valid starting in release 21.03:
 
 ```ssh
 dgraph alpha --ludicrous_mode=true ludicrous_concurrency=16
 ```
 
-Instead, you can express this command as follows starting in release v21.03:
+Instead, you can express this command as follows starting in release 21.03:
 
 ```ssh
 dgraph alpha --ludicrous enabled=true; concurrency=16;
 ```
 
 The following table maps Dgraph CLI flags from release v20.11 and earlier that
-have been replaced by superflags in release v21.03. Any flags not shown here
-are unchanged from release v21.03.
+have been replaced by superflags (and their options) in release v21.03. Any flags
+not shown here are unchanged from release v21.03. 
 
-| Old flag | Old type | New flag and options | New type | Applies to | Note <!-- or example --> |
+| Old flag | Old type | New superflag and options | New type | Applies to | Notes |
 |---------:|:---------|---------:|:---------|:----:|:----:|
-| | | **`--acl`** | | | [Access Control List]({{< relref "enterprise-features/access-control-lists.md" >}}) flags |
-| `--acl_secret_file` | string | `secret-file` | string |`alpha`|
-| `--acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| `--acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| | | **`--badger`** | | |  [Badger](https://dgraph.io/docs/badger) flags |
-| `--max_retries` | int | `max-retries` | int |`alpha`|
-| `--badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`|
-| `--badger.cache_mb` | string | `cache-mb` | string |`bulk`|
-| `--badger.cache_percentage` | string | `cache-percentage` | string |`bulk`|
-||| (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`|
-| | | **`--graphql`** | | | [GraphQL]({{< relref "graphql/overview.md" >}}) flags  |
-| `--graphql_introspection` | bool | `introspection` | bool |`alpha`|
-| `--graphql_debug` | bool | `debug` | bool |`alpha`|
-| `--graphql_extensions` | bool | `extensions` | bool |`alpha`|
-| `--graphql_poll_interval` | time.Duration | `poll-interval` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`|
-| `--graphql_lambda_url` | string | `lambda-url` | string |`alpha`|
-| | | **`--limit`** | | | Limit-setting flags for Dgraph Alpha  |
-| `--mutations` | string | `mutations` | string |`alpha`|
-| `--query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`|
-| `--normalize_node_limit` | int | `normalize-node` | int |`alpha`|
-| `--mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`|
-| | | **`--ludicrous`** | | | [Ludicrous Mode]({{< relref "deploy/ludicrous-mode.md" >}}) flags  |
-| `--ludicrous_mode` | bool | `enabled` | bool |`alpha`|
-| `--ludicrous_concurrency` | int | `concurrency` | int |`alpha`|
-| | | **`--raft`** | | | [Raft]({{< relref "design-concepts/raft.md" >}}) flags  |
-| `--pending_proposals` | int | `pending-proposals` | int |`alpha`|
-| `--idx` | int | `idx` | int |`alpha`, `zero`|
-| `--group` | int | `group` | int |`alpha`|
-|  |  | (new)`learner` | bool | `alpha`, `zero`|
-| `--snapshot-after` | int | `snapshot-after` | bool |`alpha`|
-| | | **`--security`** | | | Security flags |
-| `--auth_token` | string | `token` | string |`alpha`|
-| `--whitelist` | string | `whitelist` | string |`alpha`|
-| | | **`--telemetry`** | | | Telemetry flags  |
-| `--telemetry` | bool | `reports` | bool |`alpha` and `zero`|
-| `--enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`|
-| | | **`--tls`** | | | [TLS]({{< relref "deploy/tls-configuration.md" >}}) flags  |
-| `--tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `--tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `--tls_server_name` | string | `server-name` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `--tls_client_auth` | string | `client-auth-type` | string |`alpha`, `zero`|
-| `--tls_node_cert` | string | `server-cert` | string |`alpha` and `zero`|
-| `--tls_node_key` | string | `server-key` | string |`alpha` and `zero`|
-| `--tls_internal_port_enabled` | bool | `internal-port` | bool | `alpha`, `zero`, `bulk`, `backup`, `live`|
-| `--tls_cert` | string | `client-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| `--tls_key` | string | `client-key` | string |`alpha`, `zero`, `bulk`, `backup`, `live`|
-| | | **`--trace`** | | | [Tracing]({{< relref "deploy/tracing.md" >}}) flags  |
-| `--trace` | float64 | `ratio` | float64 |`alpha`, `zero`|
-| `--jaeger.collector` | string | `jaeger` | string | `alpha`, `zero`|
-| `--datadog.collector` | string | `datadog` | string | `alpha`, `zero`|
-| | | **`--vault`** | | | Vault flags  |
-| `--vault_addr` | string | `addr` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
-| `--vault_roleid_file` | string | `role-id-file` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
-| `--vault_secretid_file` | string | `secret-id-file` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
-| `--vault_path` | string | `path` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
-| `--vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`|
-| `--vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`|
+| | | **`--acl`** | | | [Access Control List]({{< relref "enterprise-features/access-control-lists.md" >}}) superflag |
+| `--acl_secret_file` | string | `secret-file` | string |`alpha`| File that stores the HMAC secret that is used for signing the JWT |
+| `--acl_access_ttl` | time.Duration | `access-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`| TTL for the access JWT |
+| `--acl_refresh_ttl` | time.Duration | `refresh-ttl` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`| The TTL for the refresh JWT |
+| | | **`--badger`** | | |  [Badger](https://dgraph.io/docs/badger) superflag |
+| `--max_retries` | int | `max-retries` | int |`alpha`| Maximum number of retries |
+| `--badger.compression` | string | `compression` | string | `alpha`, `bulk`, `backup`| Specifies the compression level and algorithm |
+| `--badger.cache_mb` | string | `cache-mb` | string |`bulk`| Total size of cache (in MB) per shard in the reducer |
+| `--badger.cache_percentage` | string | `cache-percentage` | string |`bulk`| Cache percentages for block cache and index cache |
+||| (new) [`goroutines`]({{< relref "troubleshooting.md" >}}) | int |`alpha`, `bulk`, `backup`| Number of Go routines used by Dgraph |
+| | | **`--graphql`** | | | [GraphQL]({{< relref "graphql/overview.md" >}}) superflag  |
+| `--graphql_introspection` | bool | `introspection` | bool |`alpha`| Enables GraphQL schema introspection |
+| `--graphql_debug` | bool | `debug` | bool |`alpha`| Enables debug mode in GraphQL |
+| `--graphql_extensions` | bool | `extensions` | bool |`alpha`| Enables extensions in GraphQL response body |
+| `--graphql_poll_interval` | time.Duration | `poll-interval` | [string](https://github.com/dgraph-io/ristretto/blob/master/z/flags.go#L80-L98) |`alpha`| The polling interval for GraphQL subscriptions | 
+| `--graphql_lambda_url` | string | `lambda-url` | string |`alpha`| The URL of a lambda server that implements custom GraphQL JavaScript resolvers |
+| | | **`--limit`** | | | Limit-setting superflag for Dgraph Alpha  |
+| `--mutations` | string | `mutations` | string |`alpha`| Mutation mode: `allow`, `disallow`, or `strict` |
+| `--query_edge_limit` | uint64 | `query-edge` | uint64 |`alpha`| Maximum number of edges that can be returned in a query |
+| `--normalize_node_limit` | int | `normalize-node` | int |`alpha`| Maximum number of nodes that can be returned in a query that uses the normalize directive |
+| `--mutations_nquad_limit` | int | `mutations-nquad` | int |`alpha`| Maximum number of nquads that can be inserted in a mutation request |
+| | | **`--ludicrous`** | | | [Ludicrous Mode]({{< relref "deploy/ludicrous-mode.md" >}}) superflag  |
+| `--ludicrous_mode` | bool | `enabled` | bool |`alpha`| Enables Ludicrous mode |
+| `--ludicrous_concurrency` | int | `concurrency` | int |`alpha`| Number of concurrent threads to use in Ludicrous mode |
+| | | **`--raft`** | | | [Raft]({{< relref "design-concepts/raft.md" >}}) superflag  |
+| `--pending_proposals` | int | `pending-proposals` | int |`alpha`|  Maximum number of pending mutation proposals; useful for rate limiting |
+| `--idx` | int | `idx` | int |`alpha`, `zero`| Provides an optional Raft ID that an Alpha node can use to join Raft groups |
+| `--group` | int | `group` | int |`alpha`| Provides an optional Raft group ID that an Alpha node can use to request group membership from a Zero node |
+|  |  | (new)`learner` | bool | `alpha`, `zero`| Make this Alpha a learner node (used for read-only replicas) |
+| `--snapshot-after` | int | `snapshot-after` | bool |`alpha`|  Create a new Raft snapshot after the specified number of Raft entries |
+| | | **`--security`** | | | Security superflag |
+| `--auth_token` | string | `token` | string |`alpha`| Authentication token |
+| `--whitelist` | string | `whitelist` | string |`alpha`| A comma separated list of IP addresses, IP ranges, CIDR blocks, or hostnames for administration |
+| | | **`--telemetry`** | | | Telemetry superflag  |
+| `--telemetry` | bool | `reports` | bool |`alpha` and `zero`| Sends anonymous telemetry data to Dgraph |
+| `--enable_sentry` | bool | `sentry` | bool |`alpha` and `zero`| Enable sending crash events to Sentry |
+| | | **`--tls`** | | | [TLS]({{< relref "deploy/tls-configuration.md" >}}) superflag  |
+| `--tls_cacert` | string | `ca-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`| The CA cert file used to verify server certificates |
+| `--tls_use_system_ca` | bool | `use-system-ca` | bool |`alpha`, `zero`, `bulk`, `backup`, `live`| Include System CA with Dgraph Root CA |
+| `--tls_server_name` | string | `server-name` | string |`alpha`, `zero`, `bulk`, `backup`, `live`| Server name, used for validating the server’s TLS host name |
+| `--tls_client_auth` | string | `client-auth-type` | string |`alpha`, `zero`| TLS client authentication used to validate client connections from external ports |
+| `--tls_node_cert` | string | `server-cert` | string |`alpha` and `zero`|  Path and filename of the node certificate (for example, `node.crt`) |
+| `--tls_node_key` | string | `server-key` | string |`alpha` and `zero`| Path and filename of the node certificate private key (for example, `node.key`) |
+| `--tls_internal_port_enabled` | bool | `internal-port` | bool | `alpha`, `zero`, `bulk`, `backup`, `live`| Makes internal ports (by default, 5080 and 7080) use the REQUIREANDVERIFY setting. |
+| `--tls_cert` | string | `client-cert` | string |`alpha`, `zero`, `bulk`, `backup`, `live`| User cert file provided by the client to the Alpha node |
+| `--tls_key` | string | `client-key` | string |`alpha`, `zero`, `bulk`, `backup`, `live`| User private key file provided by the client to the Alpha node |
+| | | **`--trace`** | | | [Tracing]({{< relref "deploy/tracing.md" >}}) superflag  |
+| `--trace` | float64 | `ratio` | float64 |`alpha`, `zero`| The ratio of queries to trace |
+| `--jaeger.collector` | string | `jaeger` | string | `alpha`, `zero`| URL of Jaeger to send OpenCensus traces |
+| `--datadog.collector` | string | `datadog` | string | `alpha`, `zero`| URL of Datadog to send OpenCensus traces
+| | | **`--vault`** | | | Vault superflag  |
+| `--vault_addr` | string | `addr` | string | `alpha`, `bulk`, `backup`, `live`, `debug`| Vault server address, formatted as of `http://ip-address:port` |
+| `--vault_roleid_file` | string | `role-id-file` | string | `alpha`, `bulk`, `backup`, `live`, `debug`| File containing Vault `role-id` used for AppRole authentication |
+| `--vault_secretid_file` | string | `secret-id-file` | string |`alpha`, `bulk`, `backup`, `live`, `debug`| File containing Vault `secret-id` used for AppRole authentication |
+| `--vault_path` | string | `path` | string | `alpha`, `bulk`, `backup`, `live`, `debug`| Vault key=value store path (example: `secret/data/dgraph` for kv-v2, `kv/dgraph` for kv-v1) |
+| `--vault_field` | string | `field` | string |`alpha`, `bulk`, `backup`, `live`, `debug`| Vault key=value store field whose value is the base64 encoded encryption key |
+| `--vault_format` | string | `format` | string | `alpha`, `bulk`, `backup`, `live`, `debug`| Vault field format (`raw` or `base64`) |
 
-To learn more about each of these flags, see the `--help` output of the Dgraph
-CLI commands listed in the following section.
+To learn more about each superflag and its options, see the `--help` output of
+the Dgraph CLI commands listed in the following section.
 
 ## Dgraph CLI command help listing
 
@@ -121,7 +134,7 @@ help for these commands is replicated inline below for your reference, or you
 can find help by calling these commands (or their subcommands) using the `--help`
 flag.
 
-{{% notice "Note" %}}
+{{% notice "note" %}}
 Although many of the commands listed below have subcommands, only `dgraph` and
 subcommands of `dgraph` are included in this listing. 
 {{% /notice %}}
@@ -144,7 +157,7 @@ The commands in these groups are shown in the following table:
 | Data loading     | [`bulk`](#dgraph-bulk) | Dgraph [Bulk Loader]({{< relref "deploy/fast-data-loading/bulk-loader.md" >}}) commands     |
 | Data loading     | [`live`](#dgraph-live) | Dgraph [Live Loader]({{< relref "deploy/fast-data-loading/live-loader.md" >}}) commands     |
 | Data loading     | [`restore`](#dgraph-restore) | Command used to restore backups created using Dgraph Enterprise Edition     |
-| Dgraph security  | [`acl`](#dgraph-acl) | Dgraph access control list ([ACL]({{< relref "enterprise-features/access-control-lists.md" >}})) commands |
+| Dgraph security  | [`acl`](#dgraph-acl) | Dgraph [Access Control List (ACL)]({{< relref "enterprise-features/access-control-lists.md" >}}) commands |
 | Dgraph security  | [`audit`](#dgraph-audit) | Decrypt audit files     |
 | Dgraph security  | [`cert`](#dgraph-cert) | Configure TLS and manage TLS certificates     |
 | Dgraph debug     | [`debug`](#dgraph-debug)    | Used to debug issues with Dgraph     |
@@ -164,14 +177,7 @@ The commands in these groups are shown in the following table:
 This command is the root for all commands in the Dgraph CLI. Key information from
 the help listing for `dgraph --help` is shown below:
 
-```
-Dgraph is a horizontally scalable and distributed graph database,
-providing ACID transactions, consistent replication and linearizable reads.
-It's built from the ground up to perform for a rich set of queries. Being a native
-graph database, it tightly controls how the data is arranged on disk to optimize
-for query performance and throughput, reducing disk seeks and network calls in a
-cluster.
-
+```shell
 Usage:
   dgraph [command] 
 
@@ -239,7 +245,7 @@ This command is used to configure and run the Dgraph Alpha database nodes in
 your deployment. The following replicates the help listing for `dgraph alpha --help`:
 
 
-```
+```shell
 A Dgraph Alpha instance stores the data. Each Dgraph Alpha is responsible for
 storing and serving one data group. If multiple Alphas serve the same group,
 they form a Raft group and provide synchronous replication.
@@ -358,7 +364,7 @@ This command is used to configure and run the Dgraph Zero management nodes in
 your deployment. The following replicates the help listing shown when you run
 `dgraph zero --help`:
 
-```
+```shell
 
 A Dgraph Zero instance manages the Dgraph cluster.  Typically, a single Zero
 instance is sufficient for the cluster; however, one can run multiple Zero
@@ -422,7 +428,7 @@ This command is used to bulk load data with the Dgraph
 [Bulk Loader]({{< relref "deploy/fast-data-loading/bulk-loader.md"  >}}) tool.
 The following replicates the help listing shown when you run `dgraph bulk --help`:
 
-```
+```shell
 Run Dgraph Bulk Loader 
 Usage:
  dgraph bulk [flags] 
@@ -488,7 +494,7 @@ This command is used to load live data with the Dgraph
 [Live Loader]({{< relref "deploy/fast-data-loading/live-loader.md" >}}) tool. The
 following replicates the help listing shown when you run `dgraph live --help`:
 
-```
+```shell
 Run Dgraph Live Loader 
 Usage:
  dgraph live [flags] 
@@ -546,7 +552,7 @@ Use "dgraph live [command] --help" for more information about a command.
 This command loads objects from available backups. The following replicates the
 help listing shown when you run `dgraph restore --help`:
 
-```
+```shell
 Restore loads objects created with the backup feature in Dgraph Enterprise Edition (EE).
 
 Backups are originated from HTTP at /admin/backup, then can be restored using CLI restore
@@ -634,7 +640,7 @@ certificates, and audit database usage.
 This command runs the Dgraph Enterprise Edition ACL tool. The following replicates
 the help listing shown when you run `dgraph acl --help`:
 
-```
+```shell
 Run the Dgraph Enterprise Edition ACL tool 
 Usage:
  dgraph acl [command] 
@@ -671,7 +677,7 @@ This command decrypts audit files. These files are created using the `--audit`
 when you run the `dgraph alpha` command. The following replicates the help listing
 shown when you run `dgraph audit --help`:
 
-```
+```shell
 Dgraph audit tool 
 Usage:
  dgraph audit [command] 
@@ -687,10 +693,10 @@ Use "dgraph audit [command] --help" for more information about a command.
 
 #### `dgraph cert`
 
-This command lets you manage TLS certificates. The following replicates the help
-listing shown when you run `dgraph cert --help`:
+This command lets you manage [TLS certificates]({{< relref "deploy/tls-configuration.md" >}}).
+The following replicates the help listing shown when you run `dgraph cert --help`:
 
-```
+```shell
 Dgraph TLS certificate management 
 Usage:
  dgraph cert [flags]
@@ -717,14 +723,14 @@ Use "dgraph cert [command] --help" for more information about a command.
 ### Dgraph debug commands
 
 Dgraph debug commands provide support for debugging issues with Dgraph deployments.
-To learn more, see [Using the Debug Tool]({{< relref "howto/using-increment-tool.md" >}}).
+To learn more, see [Using the Debug Tool]({{< relref "howto/using-debug-tool.md" >}}).
 
 #### `dgraph debug`
 
 This command is used to debug issues with a Dgraph database instance. The
 following replicates the help listing shown when you run `dgraph debug --help`:
 
-```
+```shell
 Debug Dgraph instance 
 Usage:
  dgraph debug [flags] 
@@ -765,7 +771,7 @@ Use "dgraph debug [command] --help" for more information about a command.
 This command generates information about the current node that is useful for debugging. 
 The following replicates the help listing shown when you run `dgraph debuginfo --help`:
 
-```
+```shell
 Generate debug information on the current node 
 Usage:
  dgraph debuginfo [flags] 
@@ -792,7 +798,7 @@ manage Dgraph.
 This command generates shell completion scripts for `bash` and `zsh` CLIs. The
 following replicates the help listing shown when you run `dgraph completion --help`:
 
-```
+```shell
 Generates shell completion scripts for bash or zsh 
 Usage:
  dgraph completion [command] 
@@ -813,7 +819,7 @@ This command runs the Dgraph geographic file converter, which converts geographi
 files into RDF so that they can be consumed by Dgraph. The following replicates
 the help listing shown when you run `dgraph conv --help`:
 
-```
+```shell
 Dgraph Geo file converter 
 Usage:
  dgraph conv [flags] 
@@ -833,7 +839,7 @@ This command lets you decrypt an export file created by an encrypted Dgraph
 cluster. The following replicates the help listing shown when you run
 `dgraph decrypt --help`:
 
-```
+```shell
 A tool to decrypt an export file created by an encrypted Dgraph cluster 
 Usage:
  dgraph decrypt [flags] 
@@ -861,7 +867,7 @@ This command is used to convert a [binary backup]({{< relref "enterprise-feature
 created using Dgraph Enterprise Edition into an exported folder. The following
 replicates key information from the help listing shown when you run `dgraph export_backup --help`:
 
-```
+```shell
 Usage:
   dgraph export_backup [flags] 
 
@@ -892,7 +898,7 @@ an Alpha node is able to handle both query and mutation requests. To learn more,
 see [Using the Increment Tool]({{< relref "howto/using-increment-tool.md" >}}). 
 The following replicates the help listing shown when you run `dgraph increment --help`:
 
-```
+```shell
 Increment a counter transactionally 
 Usage:
  dgraph increment [flags] 
@@ -930,7 +936,7 @@ This command lists information on backups in a given location for Dgraph Enterpr
 Edition. To learn more, see [Backup List Tool]({{< relref "enterprise-features/lsbackup.md" >}}).
 The following replicates the help listing shown when you run `dgraph lsbackup --help`:
 
-```
+```shell
 List info on backups in a given location 
 Usage:
  dgraph lsbackup [flags] 
@@ -945,10 +951,11 @@ Use "dgraph lsbackup [command] --help" for more information about a command.
 
 #### `dgraph migrate`
 
-This command runs the Dgraph migration tool to move data from a MySQL database to Dgraph. 
-The following replicates the help listing shown when you run `dgraph migrate --help`:
+This command runs the Dgraph [migration tool]({{< relref "migration/migrate-tool.md" >}})
+to move data from a MySQL database to Dgraph. The following replicates the help
+listing shown when you run `dgraph migrate --help`:
 
-```
+```shell
 Run the Dgraph migration tool from a MySQL database to Dgraph 
 Usage:
  dgraph migrate [flags] 
@@ -974,7 +981,7 @@ Use "dgraph migrate [command] --help" for more information about a command.
 This command runs the Dgraph Raft migration tool.<!-- TBD need to say more about this --> 
 The following replicates the help listing shown when you run `dgraph raftmigrate --help`:
 
-```
+```shell
 Run the Raft migration tool 
 Usage:
  dgraph raftmigrate [flags] 
@@ -1001,7 +1008,7 @@ Use "dgraph raftmigrate [command] --help" for more information about a command.
 This command helps you to upgrade from an earlier Dgraph release to a newer release. 
 The following replicates the help listing shown when you run `dgraph upgrade --help`:
 
-```
+```shell
 This tool is supported only for the mainstream release versions of Dgraph, not for the beta releases. 
 Usage:
  dgraph upgrade [flags] 

--- a/content/deploy/troubleshooting.md
+++ b/content/deploy/troubleshooting.md
@@ -1,6 +1,6 @@
 +++
 title = "Troubleshooting"
-weight = 20
+weight = 21
 [menu.main]
     parent = "deploy"
 +++


### PR DESCRIPTION
Added information on new flags and options, and how they map to earlier flags, per https://github.com/dgraph-io/dgraph/pull/7436, https://github.com/dgraph-io/dgraph/pull/7491, and https://github.com/dgraph-io/dgraph/pull/7544

Also, added a "Dgraph CLI Command Reference", per prior discussion with @OmarAyo.

Staged here: https://deploy-preview-111--dgraph-docs-repo.netlify.app/deploy/cli-command-ref/

Fixes DOC-168

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
