### PR TITLE
Docs(GraphQL): Add a tip about errors during schema update

### DIFF
--- a/content/graphql/admin/index.md
+++ b/content/graphql/admin/index.md
@@ -375,7 +375,7 @@ There are two ways you can modify a GraphQL schema:
 - Using the `updateGQLSchema` mutation on `/admin`
 
 {{% notice "tip" %}}
-While modifying the GraphQL schema, if you get errors like `errIndexingInProgress`, `another operation is already running` or `server is not ready`, then please wait for a bit and then retry the schema update.
+While modifying the GraphQL schema, if you get errors like `errIndexingInProgress`, `another operation is already running` or `server is not ready`, please wait for a moment and then retry the schema update.
 {{% /notice %}}
 
 ### Using `/admin/schema`

--- a/content/graphql/admin/index.md
+++ b/content/graphql/admin/index.md
@@ -374,6 +374,10 @@ There are two ways you can modify a GraphQL schema:
 - Using `/admin/schema`
 - Using the `updateGQLSchema` mutation on `/admin`
 
+{{% notice "tip" %}}
+While modifying the GraphQL schema, if you get errors like `errIndexingInProgress`, `another operation is already running` or `server is not ready`, then please wait for a bit and then retry the schema update.
+{{% /notice %}}
+
 ### Using `/admin/schema`
 
 The `/admin/schema` endpoint provides a simplified method to add and update schemas.
@@ -411,10 +415,6 @@ mutation {
   }
 }
 ```
-
-{{% notice "tip" %}}
-While modifying the GraphQL schema, if you get errors like `errIndexingInProgress`, `another operation is already running` or `server is not ready`, then please wait for a bit and then retry the schema update.
-{{% /notice %}}
 
 ## Using `querySchemaHistory` to see schema history
 

--- a/content/graphql/admin/index.md
+++ b/content/graphql/admin/index.md
@@ -412,6 +412,10 @@ mutation {
 }
 ```
 
+{{% notice "tip" %}}
+While modifying the GraphQL schema, if you get errors like `errIndexingInProgress`, `another operation is already running` or `server is not ready`, then please wait for a bit and then retry the schema update.
+{{% /notice %}}
+
 ## Using `querySchemaHistory` to see schema history
 
 You can query the history of your schema using `querySchemaHistory` on the


### PR DESCRIPTION
Fixes GRAPHQL-1085

This PR adds a tip about the errors during GraphQL schema update which should be retried by the user.
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
