### PR TITLE
Docs (GraphQL): 21.03 feature documentation for lambda webhooks

### DIFF
--- a/content/graphql/directives/index.md
+++ b/content/graphql/directives/index.md
@@ -102,3 +102,9 @@ Reference: [Skip directive](/graphql/queries/skip-include)
 `@withSubscription` directive when applied on a type, generates subsciption queries for it.
 
 Reference: [Subscriptions](/graphql/subscriptions)
+
+### @lambdaOnMutate
+
+The `@lambdaOnMutate` directive allows you to listen on mutation events(`add`/`update`/`delete`). The `@lambdaOnMutate` depending on the mutation events defined and on occurence of a mutation event, triggers the appropriate lambda function implemented on a given lambda server.
+
+Reference: [LambdaOnMutate directive](/graphql/lambda/webhook)

--- a/content/graphql/directives/index.md
+++ b/content/graphql/directives/index.md
@@ -105,6 +105,6 @@ Reference: [Subscriptions](/graphql/subscriptions)
 
 ### @lambdaOnMutate
 
-The `@lambdaOnMutate` directive allows you to listen on mutation events(`add`/`update`/`delete`). The `@lambdaOnMutate` depending on the mutation events defined and on occurence of a mutation event, triggers the appropriate lambda function implemented on a given lambda server.
+The `@lambdaOnMutate` directive allows you to listen to mutation events(`add`/`update`/`delete`). Depending on the defined events and the occurrence of a mutation event, `@lambdaOnMutate` triggers the appropriate lambda function implemented on a given lambda server.
 
 Reference: [LambdaOnMutate directive](/graphql/lambda/webhook)

--- a/content/graphql/lambda/server.md
+++ b/content/graphql/lambda/server.md
@@ -1,7 +1,7 @@
 +++
 title = "Lambda Server"
 description = "Setup a Dgraph database with a lambda server. Dgraph Lambda is a serverless platform for running JavaScript on Dgraph and Slash GraphQL."
-weight = 5
+weight = 6
 [menu.main]
     parent = "lambda"
 +++

--- a/content/graphql/lambda/webhook.md
+++ b/content/graphql/lambda/webhook.md
@@ -1,0 +1,95 @@
++++
+title = "Lambda Webhooks"
+description = "Ready to use lambdas for webhooks? This documentation takes you through the schemas, resolvers, and examples."
+weight = 5
+[menu.main]
+    parent = "lambda"
++++
+
+### Schema
+
+To set up a lambda webhook, first you need to define it in your GraphQL schema by using the `@lambdaOnMutate` directive along with the mutation events (add/update/delete) you want to listen on.
+
+For example, to define a lambda webhook for all mutation events (add/update/delete) on any `Author` object:
+
+```graphql
+type Author @lambdaOnMutate(add: true, update: true, delete: true) {
+    id: ID!
+    name: String! @search(by: [hash, trigram])
+    dob: DateTime
+    reputation: Float
+}
+```
+
+### Resolver
+
+Once the schema is ready, you can define your JavaScript functions and add those as resolvers in your JS source code. 
+To add the resolvers you should use the `addWebHookResolvers`method.
+
+{{% notice "note" %}}
+A Lambda Webhook resolver can use a combination of `event`, `dql`, `graphql` or `authHeader` inside the function.
+{{% /notice %}}
+
+You have access to the `event` object within the resolver. The definition of `event` is something as follows:
+
+```
+"event": {
+    "__typename": "<Typename>",
+    "operation": "<one-of: add/update/delete>",
+    "commitTs": <uint64, the commitTs of the mutation>
+    "add": {
+      "rootUIDs": [<list-of-UIDs-that-were-created-for-root-nodes-in-this-mutation>],
+      "input": [<AddTypeInput: i.e. all the data that was received as part of the `input` argument>]
+    },
+    "update": {
+      "rootUIDs": [<list-of-UIDs-of-root-nodes-for-which-somethig-was-set/removed-in-this-mutation>],
+      "setPatch": <TypePatch: the object that was received as the patch for set>,
+      "removePatch": <TypePatch: the object that was received as the patch for remove>
+    },
+    "delete": {
+      "rootUIDs": [<list-of-UIDs-of-root-nodes-which-were-deleted-in-this-mutation>]
+    }
+```
+
+For example, to define the JavaScript lambda functions for each mutation event for which `@lambdaOnMutate` is enabled and add those as resolvers:
+
+```javascript
+async function addAuthorWebhook({event, dql, graphql, authHeader}) {
+    // execute what you want on addition of an author 
+    // maybe send a welcome mail to the author
+    
+}
+
+async function updateAuthorWebhook({event, dql, graphql, authHeader}) {
+    // execute what you want on updation of an author
+    // maybe send a mail to the author informing that few details have been updated 
+    
+}
+
+async function deleteAuthorWebhook({event, dql, graphql, authHeader}) {
+    // execute what you want on deletion of an author
+    // maybe mail the author saying they have been removed from the platform 
+    
+}
+
+self.addWebHookResolvers({
+    "Author.add": addAuthorWebhook,
+    "Author.update": updateAuthorWebhook,
+    "Author.delete": deleteAuthorWebhook,
+})
+```
+
+### Example
+
+Finally, if you execute a `addAuthor` mutation the resolver `addAuthorWebhook` mapped to `add` operation will get triggered :
+
+```graphql
+mutation {
+  addAuthor(input:[{name: "Ken Addams"}]) {
+    author {
+      id
+      name
+    }
+  }
+}
+```

--- a/content/graphql/lambda/webhook.md
+++ b/content/graphql/lambda/webhook.md
@@ -32,7 +32,7 @@ A Lambda Webhook resolver can use a combination of `event`, `dql`, `graphql` or 
 
 #### Event object
 
-You also have access to the `event` object within the resolver. The definition of `event` is as follows:
+You also have access to the `event` object within the resolver. Depending on the value of `operation` field, only one of the fields (`add`/`update`/`delete`) will be part of the `event` object. The definition of `event` is as follows:
 
 ```
 "event": {

--- a/content/graphql/lambda/webhook.md
+++ b/content/graphql/lambda/webhook.md
@@ -8,9 +8,9 @@ weight = 5
 
 ### Schema
 
-To set up a lambda webhook, first you need to define it in your GraphQL schema by using the `@lambdaOnMutate` directive along with the mutation events (add/update/delete) you want to listen on.
+To set up a lambda webhook, you need to define it in your GraphQL schema by using the `@lambdaOnMutate` directive along with the mutation events (`add`/`update`/`delete`) you want to listen on.
 
-For example, to define a lambda webhook for all mutation events (add/update/delete) on any `Author` object:
+For example, to define a lambda webhook for all mutation events (`add`/`update`/`delete`) on any `Author` object:
 
 ```graphql
 type Author @lambdaOnMutate(add: true, update: true, delete: true) {
@@ -30,7 +30,9 @@ To add the resolvers you should use the `addWebHookResolvers`method.
 A Lambda Webhook resolver can use a combination of `event`, `dql`, `graphql` or `authHeader` inside the function.
 {{% /notice %}}
 
-You have access to the `event` object within the resolver. The definition of `event` is something as follows:
+#### Event object
+
+You also have access to the `event` object within the resolver. The definition of `event` is as follows:
 
 ```
 "event": {
@@ -51,7 +53,9 @@ You have access to the `event` object within the resolver. The definition of `ev
     }
 ```
 
-For example, to define the JavaScript lambda functions for each mutation event for which `@lambdaOnMutate` is enabled and add those as resolvers:
+#### Resolver examples
+
+For example, to define JavaScript lambda functions for each mutation event for which `@lambdaOnMutate` is enabled and add those as resolvers:
 
 ```javascript
 async function addAuthorWebhook({event, dql, graphql, authHeader}) {
@@ -81,7 +85,7 @@ self.addWebHookResolvers({
 
 ### Example
 
-Finally, if you execute a `addAuthor` mutation the resolver `addAuthorWebhook` mapped to `add` operation will get triggered :
+Finally, if you execute an `addAuthor` mutation, the `add` operation mapped to the `addAuthorWebhook` resolver will be triggered:
 
 ```graphql
 mutation {


### PR DESCRIPTION
Docs regarding lambda webhooks.
Fixes DOC-199

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
