### PR TITLE
add auth header

### DIFF
--- a/content/graphql/lambda/field.md
+++ b/content/graphql/lambda/field.md
@@ -8,18 +8,20 @@ weight = 2
 
 ### Schema
 
-To set up a lambda function, first you need to define it on your GraphQL schema by using the `@lambda` directive.
+To set up a lambda function, first you need to define it on your GraphQL schema
+by using the `@lambda` directive.
 
-For example, to define a lambda function for the `rank` and `bio` fields in `Author`: 
+For example, to define a lambda function for the `rank` and `bio` fields in
+`Author`:
 
 ```graphql
 type Author {
-        id: ID!
-        name: String! @search(by: [hash, trigram])
-        dob: DateTime @search
-        reputation: Float @search
-        bio: String @lambda
-        rank: Int @lambda
+  id: ID!
+  name: String! @search(by: [hash, trigram])
+  dob: DateTime @search
+  reputation: Float @search
+  bio: String @lambda
+  rank: Int @lambda
 }
 ```
 
@@ -27,71 +29,69 @@ You can also define `@lambda` fields on interfaces:
 
 ```graphql
 interface Character {
-        id: ID!
-        name: String! @search(by: [exact])
-        bio: String @lambda
+  id: ID!
+  name: String! @search(by: [exact])
+  bio: String @lambda
 }
 
 type Human implements Character {
-        totalCredits: Float
+  totalCredits: Float
 }
 
 type Droid implements Character {
-        primaryFunction: String
+  primaryFunction: String
 }
 ```
 
 ### Resolvers
 
-Once the schema is ready, you can define your JavaScript mutation function and add it as a resolver in your JS source code. 
-To add the resolver you can use either the `addGraphQLResolvers` or `addMultiParentGraphQLResolvers` methods.
+Once the schema is ready, you can define your JavaScript mutation function and
+add it as a resolver in your JS source code. To add the resolver you can use
+either the `addGraphQLResolvers` or `addMultiParentGraphQLResolvers` methods.
 
-{{% notice "note" %}}
-A Lambda Field resolver can use a combination of `parents`, `parent`, `dql`, or `graphql` inside the function.
-{{% /notice %}}
+For example, to define JavaScript lambda functions for...
 
-{{% notice "tip" %}}
-This example uses `parent` for the resolver function. You can find additional resolver examples using `dql` in the [Lambda queries article]({{< relref "query.md" >}}), and using `graphql` in the [Lambda mutations article]({{< relref "mutation.md" >}}).
-{{% /notice %}}
-
-For example, to define JavaScript lambda functions for... 
-- `Author`, 
-- `Character`, 
-- `Human`, and 
+- `Author`,
+- `Character`,
+- `Human`, and
 - `Droid`
 
 ...and add them as resolvers, do the following:
 
 ```javascript
-const authorBio = ({parent: {name, dob}}) => `My name is ${name} and I was born on ${dob}.`
-const characterBio = ({parent: {name}}) => `My name is ${name}.`
-const humanBio = ({parent: {name, totalCredits}}) => `My name is ${name}. I have ${totalCredits} credits.`
-const droidBio = ({parent: {name, primaryFunction}}) => `My name is ${name}. My primary function is ${primaryFunction}.`
+const authorBio = ({ parent: { name, dob } }) =>
+  `My name is ${name} and I was born on ${dob}.`;
+const characterBio = ({ parent: { name } }) => `My name is ${name}.`;
+const humanBio = ({ parent: { name, totalCredits } }) =>
+  `My name is ${name}. I have ${totalCredits} credits.`;
+const droidBio = ({ parent: { name, primaryFunction } }) =>
+  `My name is ${name}. My primary function is ${primaryFunction}.`;
 
 self.addGraphQLResolvers({
-    "Author.bio": authorBio,
-    "Character.bio": characterBio,
-    "Human.bio": humanBio,
-    "Droid.bio": droidBio
-})
+  "Author.bio": authorBio,
+  "Character.bio": characterBio,
+  "Human.bio": humanBio,
+  "Droid.bio": droidBio,
+});
 ```
 
 Another example, adding a resolver for `rank` using a `graphql` call:
 
 ```javascript
-async function rank({parents}) {
-    const idRepList = parents.map(function (parent) {
-        return {id: parent.id, rep: parent.reputation}
-    });
-    const idRepMap = {};
-    idRepList.sort((a, b) => a.rep > b.rep ? -1 : 1)
-        .forEach((a, i) => idRepMap[a.id] = i + 1)
-    return parents.map(p => idRepMap[p.id])
+async function rank({ parents }) {
+  const idRepList = parents.map(function (parent) {
+    return { id: parent.id, rep: parent.reputation };
+  });
+  const idRepMap = {};
+  idRepList
+    .sort((a, b) => (a.rep > b.rep ? -1 : 1))
+    .forEach((a, i) => (idRepMap[a.id] = i + 1));
+  return parents.map((p) => idRepMap[p.id]);
 }
 
 self.addMultiParentGraphQLResolvers({
-    "Author.rank": rank
-})
+  "Author.rank": rank,
+});
 ```
 
 ### Example
@@ -100,11 +100,11 @@ If you execute this lambda query
 
 ```graphql
 query {
-	queryAuthor {
-		name
-		bio
-		rank
-	}
+  queryAuthor {
+    name
+    bio
+    rank
+  }
 }
 ```
 
@@ -112,13 +112,13 @@ You should see a response such as
 
 ```json
 {
-	"queryAuthor": [
-		{
-			"name":"Ann Author",
-			"bio":"My name is Ann Author and I was born on 2000-01-01T00:00:00Z.",
-			"rank":3
-		}
-	]
+  "queryAuthor": [
+    {
+      "name": "Ann Author",
+      "bio": "My name is Ann Author and I was born on 2000-01-01T00:00:00Z.",
+      "rank": 3
+    }
+  ]
 }
 ```
 
@@ -126,10 +126,10 @@ In the same way, if you execute this lambda query on the `Character` interface
 
 ```graphql
 query {
-	queryCharacter {
-		name
-		bio
-	}
+  queryCharacter {
+    name
+    bio
+  }
 }
 ```
 
@@ -137,22 +137,24 @@ You should see a response such as
 
 ```json
 {
-	"queryCharacter": [
-		{
-			"name":"Han",
-			"bio":"My name is Han."
-		},
-		{
-			"name":"R2-D2",
-			"bio":"My name is R2-D2."
-		}
-	]
+  "queryCharacter": [
+    {
+      "name": "Han",
+      "bio": "My name is Han."
+    },
+    {
+      "name": "R2-D2",
+      "bio": "My name is R2-D2."
+    }
+  ]
 }
 ```
 
-Note that the `Human` and `Droid` types will inherit the `bio` lambda field from the `Character` interface. 
+Note that the `Human` and `Droid` types will inherit the `bio` lambda field from
+the `Character` interface.
 
-For example, if you execute a `queryHuman` query with a selection set containing `bio`, then the lambda function registered for `Human.bio` will be executed:
+For example, if you execute a `queryHuman` query with a selection set containing
+`bio`, then the lambda function registered for `Human.bio` will be executed:
 
 ```graphql
 query {

--- a/content/graphql/lambda/overview.md
+++ b/content/graphql/lambda/overview.md
@@ -8,27 +8,39 @@ weight = 1
     name = "Overview"
 +++
 
-Lambda provides a way to write your custom logic in JavaScript, integrate it with your GraphQL schema, and execute it using the GraphQL API in a few easy steps:
+Lambda provides a way to write your custom logic in JavaScript, integrate it
+with your GraphQL schema, and execute it using the GraphQL API in a few easy
+steps:
 
-- Setup a Dgraph cluster with a working lambda server (not required for [Slash GraphQL](https://dgraph.io/slash-graphql) users)
+- Setup a Dgraph cluster with a working lambda server (not required for
+  [Slash GraphQL](https://dgraph.io/slash-graphql) users)
 - Declare lambda queries, mutations, and fields in your GraphQL schema as needed
 - Define lambda resolvers for them in a JavaScript file
 
-This also simplifies the job of developers, as they can build a complex backend that is rich with business logic, without setting up multiple different services. Also, you can build your backend in JavaScript, which means you can build both your frontend and backend using the same language.
+This also simplifies the job of developers, as they can build a complex backend
+that is rich with business logic, without setting up multiple different
+services. Also, you can build your backend in JavaScript, which means you can
+build both your frontend and backend using the same language.
 
-Dgraph doesn't execute your custom logic itself. It makes external HTTP requests to a user-defined lambda server. [Slash GraphQL](https://dgraph.io/slash-graphql) will do all of this for you. 
+Dgraph doesn't execute your custom logic itself. It makes external HTTP requests
+to a user-defined lambda server.
+[Slash GraphQL](https://dgraph.io/slash-graphql) will do all of this for you.
 
-{{% notice "tip" %}}
-If you want to deploy your own lambda server, you can find the implementation of Dgraph Lambda in our [open-source repository](https://github.com/dgraph-io/dgraph-lambda). Please refer to the documentation on [setting up a lambda server](/graphql/lambda/server) for more details.
+{{% notice "tip" %}} If you want to deploy your own lambda server, you can find
+the implementation of Dgraph Lambda in our
+[open-source repository](https://github.com/dgraph-io/dgraph-lambda). Please
+refer to the documentation on
+[setting up a lambda server](/graphql/lambda/server) for more details.
 {{% /notice %}}
 
-{{% notice "note" %}}
-If you're using [Slash GraphQL](https://dgraph.io/slash-graphql), the final compiled script file must be under 500Kb
-{{% /notice %}}
+{{% notice "note" %}} If you're using
+[Slash GraphQL](https://dgraph.io/slash-graphql), the final compiled script file
+must be under 500Kb {{% /notice %}}
 
 ## Declaring lambda in a GraphQL schema
 
-There are three places where you can use the `@lambda` directive and thus tell Dgraph where to apply custom JavaScript logic.
+There are three places where you can use the `@lambda` directive and thus tell
+Dgraph where to apply custom JavaScript logic.
 
 1. You can add lambda fields to your types and interfaces
 
@@ -57,27 +69,36 @@ type Mutation {
 
 ## Defining lambda resolvers in JavaScript
 
-A lambda resolver is a user-defined JavaScript function that performs custom actions over the GraphQL types, interfaces, queries, and mutations. There are two methods to register JavaScript resolvers:
+A lambda resolver is a user-defined JavaScript function that performs custom
+actions over the GraphQL types, interfaces, queries, and mutations. There are
+two methods to register JavaScript resolvers:
 
 - `self.addGraphQLResolvers`
 - `self.addMultiParentGraphQLResolvers`
 
-{{% notice "tip" %}}
-Functions `self.addGraphQLResolvers` and `self.addMultiParentGraphQLResolvers` can be called multiple times in your resolver code.
-{{% /notice %}}
+{{% notice "tip" %}} Functions `self.addGraphQLResolvers` and
+`self.addMultiParentGraphQLResolvers` can be called multiple times in your
+resolver code. {{% /notice %}}
 
 ### addGraphQLResolvers
 
-The `self.addGraphQLResolvers` method takes an object as an argument, which maps a resolver name to the resolver function that implements it. The resolver functions registered using `self.addGraphQLResolvers` receive `{ parent, args, graphql, dql }` as argument:
+The `self.addGraphQLResolvers` method takes an object as an argument, which maps
+a resolver name to the resolver function that implements it. The resolver
+functions registered using `self.addGraphQLResolvers` receive
+`{ parent, args, graphql, dql }` as argument:
 
-- `parent`, the parent object for which to resolve the current lambda field registered using `addGraphQLResolver`.
-The `parent` receives all immediate fields of that object, whether or not they were actually queried.
-Available only for types and interfaces (`null` for queries and mutations)
-- `args`,  the set of arguments for lambda queries and mutations
-- `graphql`, a function to execute auto-generated GraphQL API calls from the lambda server. The user's auth header is passed back to the `graphql` function, so this can be used securely
+- `parent`, the parent object for which to resolve the current lambda field
+  registered using `addGraphQLResolver`. The `parent` receives all immediate
+  fields of that object, whether or not they were actually queried. Available
+  only for types and interfaces (`null` for queries and mutations)
+- `args`, the set of arguments for lambda queries and mutations
+- `graphql`, a function to execute auto-generated GraphQL API calls from the
+  lambda server. The user's auth header is passed back to the `graphql`
+  function, so this can be used securely
 - `dql`, provides an API to execute DQL from the lambda server
 
-The `addGraphQLResolvers` can be represented with the following TypeScript types:
+The `addGraphQLResolvers` can be represented with the following TypeScript
+types:
 
 ```TypeScript
 type GraphQLResponse {
@@ -100,50 +121,64 @@ function addGraphQLResolvers(resolvers: {
 }): void
 ```
 
-{{% notice "tip" %}}
-`self.addGraphQLResolvers` is the default choice for registering resolvers when the result of the lambda for each parent is independent of other parents.
-{{% /notice %}}
+{{% notice "tip" %}} `self.addGraphQLResolvers` is the default choice for
+registering resolvers when the result of the lambda for each parent is
+independent of other parents. {{% /notice %}}
 
-Each resolver function should return data in the exact format as the return type of GraphQL field, query, or mutation for which it is being registered.
+Each resolver function should return data in the exact format as the return type
+of GraphQL field, query, or mutation for which it is being registered.
 
-In the following example, the resolver function `myTypeResolver` registered for the `customField` field in `MyType` returns a string because the return type of that field in the GraphQL schema is `String`:
+In the following example, the resolver function `myTypeResolver` registered for
+the `customField` field in `MyType` returns a string because the return type of
+that field in the GraphQL schema is `String`:
 
 ```javascript
-const myTypeResolver = ({parent: {customField}}) => `My value is ${customField}.`
+const myTypeResolver = ({ parent: { customField } }) =>
+  `My value is ${customField}.`;
 
 self.addGraphQLResolvers({
-    "MyType.customField": myTypeResolver
-})
+  "MyType.customField": myTypeResolver,
+});
 ```
 
 Another resolver example using a `graphql` call:
 
 ```javascript
 async function todoTitles({ graphql }) {
-  const results = await graphql('{ queryTodo { title } }')
-  return results.data.queryTodo.map(t => t.title)
+  const results = await graphql("{ queryTodo { title } }");
+  return results.data.queryTodo.map((t) => t.title);
 }
 
 self.addGraphQLResolvers({
-  "Query.todoTitles": todoTitles
-})
+  "Query.todoTitles": todoTitles,
+});
 ```
 
 ### addMultiParentGraphQLResolvers
 
-The `self.addMultiParentGraphQLResolvers` is useful in scenarios where you want to perform computations involving all the parents returned from Dgraph for a lambda field. This is useful in two scenarios:
+The `self.addMultiParentGraphQLResolvers` is useful in scenarios where you want
+to perform computations involving all the parents returned from Dgraph for a
+lambda field. This is useful in two scenarios:
 
 - When you want to perform a computation between parents
-- When you want to execute a complex query, and want to optimize it by firing a single query for all the parents
+- When you want to execute a complex query, and want to optimize it by firing a
+  single query for all the parents
 
-This method takes an object as an argument, which maps a resolver name to the resolver function that implements it. The resolver functions registered using this method receive `{ parents, args, graphql, dql }` as argument:
+This method takes an object as an argument, which maps a resolver name to the
+resolver function that implements it. The resolver functions registered using
+this method receive `{ parents, args, graphql, dql }` as argument:
 
-- `parents`, a list of parent objects for which to resolve the current lambda field registered using `addMultiParentGraphQLResolvers`. Available only for types and interfaces (`null` for queries and mutations)
-- `args`,  the set of arguments for lambda queries and mutations (`null` for types and interfaces)
-- `graphql`, a function to execute auto-generated GraphQL API calls from the lambda server
+- `parents`, a list of parent objects for which to resolve the current lambda
+  field registered using `addMultiParentGraphQLResolvers`. Available only for
+  types and interfaces (`null` for queries and mutations)
+- `args`, the set of arguments for lambda queries and mutations (`null` for
+  types and interfaces)
+- `graphql`, a function to execute auto-generated GraphQL API calls from the
+  lambda server
 - `dql`, provides an API to execute DQL from the lambda server
 
-The `addMultiParentGraphQLResolvers` can be represented with the following TypeScript types:
+The `addMultiParentGraphQLResolvers` can be represented with the following
+TypeScript types:
 
 ```TypeScript
 type GraphQLResponse {
@@ -166,56 +201,61 @@ function addMultiParentGraphQLResolvers(resolvers: {
 }): void
 ```
 
-{{% notice "note" %}}
-This method should not be used for lambda queries or lambda mutations.
-{{% /notice %}}
+{{% notice "note" %}} This method should not be used for lambda queries or
+lambda mutations. {{% /notice %}}
 
-Each resolver function should return data as a list of the return type of GraphQL field for which it is being registered. 
+Each resolver function should return data as a list of the return type of
+GraphQL field for which it is being registered.
 
-In the following example, the resolver function `rank()` registered for the `rank` field in `Author`, returns a list of integers because the return type of that field in the GraphQL schema is `Int`:
+In the following example, the resolver function `rank()` registered for the
+`rank` field in `Author`, returns a list of integers because the return type of
+that field in the GraphQL schema is `Int`:
 
 ```graphql
 type Author {
-    id: ID!
-    name: String! @search(by: [hash, trigram])
-    reputation: Float @search
-    rank: Int @lambda
+  id: ID!
+  name: String! @search(by: [hash, trigram])
+  reputation: Float @search
+  rank: Int @lambda
 }
 ```
 
 ```javascript
-import { sortBy } from 'lodash';
+import { sortBy } from "lodash";
 
 /* 
 This function computes the rank of each author based on the reputation of the author relative to other authors.
 */
-async function rank({parents}) {
-    const idRepMap = {};
-    sortBy(parents, 'reputation').forEach((parent, i) => idRepMap[parent.id] = parents.length - i)
-    return parents.map(p => idRepMap[p.id])
+async function rank({ parents }) {
+  const idRepMap = {};
+  sortBy(parents, "reputation").forEach(
+    (parent, i) => (idRepMap[parent.id] = parents.length - i)
+  );
+  return parents.map((p) => idRepMap[p.id]);
 }
 
 self.addMultiParentGraphQLResolvers({
-    "Author.rank": rank
-})
+  "Author.rank": rank,
+});
 ```
 
-{{% notice "note" %}}
-Scripts containing import packages (such as the example above) require compilation using Webpack.
-{{% /notice %}}
+{{% notice "note" %}} Scripts containing import packages (such as the example
+above) require compilation using Webpack. {{% /notice %}}
 
 Another resolver example using a `dql` call:
 
 ```javascript
-async function reallyComplexDql({parents, dql}) {
-  const ids = parents.map(p => p.id);
-  const someComplexResults = await dql.query(`really-complex-query-here with ${ids}`);
-  return parents.map(parent => someComplexResults[parent.id])
+async function reallyComplexDql({ parents, dql }) {
+  const ids = parents.map((p) => p.id);
+  const someComplexResults = await dql.query(
+    `really-complex-query-here with ${ids}`
+  );
+  return parents.map((parent) => someComplexResults[parent.id]);
 }
 
 self.addMultiParentGraphQLResolvers({
-  "MyType.reallyComplexProperty": reallyComplexDql
-})
+  "MyType.reallyComplexProperty": reallyComplexDql,
+});
 ```
 
 ## Example
@@ -224,9 +264,9 @@ If you execute this lambda query
 
 ```graphql
 query {
-	queryMyType {
-		customField
-	}
+  queryMyType {
+    customField
+  }
 }
 ```
 
@@ -234,19 +274,19 @@ You should see a response such as
 
 ```json
 {
-	"queryMyType": [
-		{
-			"customField":"My value is Lambda Example"
-		}
-	]
+  "queryMyType": [
+    {
+      "customField": "My value is Lambda Example"
+    }
+  ]
 }
 ```
 
 ## Learn more
 
-Find out more about the  `@lambda` directive here:
+Find out more about the `@lambda` directive here:
 
-* [Lambda fields](/graphql/lambda/field)
-* [Lambda queries](/graphql/lambda/query)
-* [Lambda mutations](/graphql/lambda/mutation)
-* [Lambda server setup](/graphql/lambda/server)
+- [Lambda fields](/graphql/lambda/field)
+- [Lambda queries](/graphql/lambda/query)
+- [Lambda mutations](/graphql/lambda/mutation)
+- [Lambda server setup](/graphql/lambda/server)


### PR DESCRIPTION
fix formatting and prettify for pages being updated.
add authHeader examples and documentation to lambda overview and field.

Note: I had to revert changes to commit the formatting and prettify changes separately from the doc content changes. I will remember to prettify and format and commit before changing content to see the content that was changed easier to review.