### PR TITLE
Docs (GraphQL): Add documentation for has filter on list of fields

### DIFF
--- a/content/graphql/queries/search-filtering.md
+++ b/content/graphql/queries/search-filtering.md
@@ -254,13 +254,14 @@ field using the `has` keyword. The `has` keyword can only check whether a field
 returns a non-null value, not for specific field values.
 
 For example, your schema might define a `Student` type that has basic
-information about each student; such as their ID number, age, and name:
+information about each student; such as their ID number, age, name, and email address:
 
 ```graphql
 type Student {
    tid: ID!
    age: Int!
    name: String
+   email: String
 }
 ```
 
@@ -273,3 +274,15 @@ queryStudent(filter: { has : name } ){
    name
 }
 ```
+You can also specify a list of fields, like the following:
+
+```graphql
+queryStudent(filter: { has : [name, email] } ){
+   tid
+   age
+   name
+   email
+}
+```
+
+This would return `Student` objects where both `name` and `email` fields are non-null.


### PR DESCRIPTION
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
Documents usage of `has` filter with a list of fields, as per PR: https://github.com/dgraph-io/dgraph/pull/7363 
Addresses [DOC-219](https://dgraph.atlassian.net/browse/DOC-219).
Preview [here](https://deploy-preview-134--dgraph-docs-repo.netlify.app/graphql/queries/search-filtering/#filter-for-objects-with-specified-non-null-fields-using-has).