### PR TITLE
Add information about using "p" dir coming from other Dgraph clusters

### DIFF
--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -259,7 +259,7 @@ Now you need to confirm whether this timestamp has been increased as expected. Y
 ```
 curl zero-address:port/state | jq
 ```
-At the end of the response, you will be looking at `"maxTxnTs"`. This should be at least equal or higher than the timestamp you assigned in the previous `curl` request
+At the end of the response, look for the value shown for `"maxTxnTs"`. This value should be greater than or equal to the timestamp you assigned in the previous `curl` request, as shown in the following example:
 
 ```json
   "maxLeaseId": "0",

--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -259,7 +259,7 @@ Now you need to double-check if this timestamp has been increased correctly. Thi
 ```
 curl zero-address:port/state | jq
 ```
-At the very end of the response, you will be looking at `"maxTxnTs"` this should be at least equal or higher than the timestamp you assigned in the previous `curl` request
+At the end of the response, you will be looking at `"maxTxnTs"`. This should be at least equal or higher than the timestamp you assigned in the previous `curl` request
 
 ```json
   "maxLeaseId": "0",

--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -274,7 +274,7 @@ At the end of the response, look for the value shown for `"maxTxnTs"`. This valu
     "enabled": true
   }
 ```
-Only at this point you can start all your Alpha nodes and check that the Snapshot created has a `ReadTs` equal or higher that the `"maxTxnTs"`.
+Now, start your Alpha nodes and check that the Snapshot created has a `ReadTs` value that's greater than or equal to the `"maxTxnTs"` value you viewed in the previous step.
 
 ```
 I0322 14:52:40.858626 2885131 draft.go:606] Creating snapshot at Index: 180, ReadTs: 10000011

--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -254,7 +254,7 @@ This will print the following message:
 ```
 {"startId":"1","endId":"10000000","readOnly":"0"}
 ```
-Now you need to double-check if this timestamp has been increased correctly. This can be checked by sending a `curl` request to the zero `/state` endpoint:
+Now you need to confirm whether this timestamp has been increased as expected. You can do this by sending a `curl` request to the zero `/state` endpoint, as follows:
 
 ```
 curl zero-address:port/state | jq

--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -247,7 +247,7 @@ In case you are using a `p` directory coming a different Dgraph cluster (e.g. yo
 After starting your Zero nodes, you need to increase the timestamp of Zero by sending the following curl request to the Zero leader node:
 
 ```
-curl "zero_address:port/assign?what=timestamps&num=X" //with X = high number e.g. 100000 or higher
+curl "zero_address:port/assign?what=timestamps&num=X" #with X = high number e.g. 100000 or higher
 ```
 and this will print the following message:
 
@@ -257,7 +257,7 @@ and this will print the following message:
 Now you need to double-check if this timestamp has been increased correctly and this can be checked by sending a curl request to the zero `/state` endpoint:
 
 ```
-curl zerp-address:port/state | jq
+curl zero-address:port/state | jq
 ```
 At the very end of the response you will be looking at `"maxTxnTs"` this should be at least equal or higher than the timestamp you assigned in the previous curl request
 

--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -242,24 +242,24 @@ Note that `snapshot at index` value must be the same within the same Alpha group
 
 ### Using "p" directories coming from different Dgraph clusters
 
-In case you are using a `p` directory coming a different Dgraph cluster (e.g. you are copying the `p` directory from your current Dgraph cluster and you want to spin up another Dgraph cluster using the same `p`) you will need to do an additional step before starting your Alpha nodes. 
+In case you are using a `p` directory coming from a different Dgraph cluster (e.g. you are copying the `p` directory from your current Dgraph cluster and you want to spin up another Dgraph cluster using the same `p`) you will need to do an additional step before starting your Alpha nodes. 
 
-After starting your Zero nodes, you need to increase the timestamp of Zero by sending the following curl request to the Zero leader node:
+After starting your Zero nodes, you need to increase the Zero's timestamp by sending the following `curl` request to the Zero leader node:
 
 ```
 curl "zero_address:port/assign?what=timestamps&num=X" #with X = high number e.g. 100000 or higher
 ```
-and this will print the following message:
+This will print the following message:
 
 ```
 {"startId":"1","endId":"10000000","readOnly":"0"}
 ```
-Now you need to double-check if this timestamp has been increased correctly and this can be checked by sending a curl request to the zero `/state` endpoint:
+Now you need to double-check if this timestamp has been increased correctly. This can be checked by sending a `curl` request to the zero `/state` endpoint:
 
 ```
 curl zero-address:port/state | jq
 ```
-At the very end of the response you will be looking at `"maxTxnTs"` this should be at least equal or higher than the timestamp you assigned in the previous curl request
+At the very end of the response, you will be looking at `"maxTxnTs"` this should be at least equal or higher than the timestamp you assigned in the previous `curl` request
 
 ```json
   "maxLeaseId": "0",

--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -242,7 +242,7 @@ Note that `snapshot at index` value must be the same within the same Alpha group
 
 ### Using "p" directories coming from different Dgraph clusters
 
-In case you are using a `p` directory coming from a different Dgraph cluster (e.g. you are copying the `p` directory from your current Dgraph cluster and you want to spin up another Dgraph cluster using the same `p`) you will need to do an additional step before starting your Alpha nodes. 
+In some cases, you might want to use the `p` directory from an existing Dgraph cluster when creating a new cluster. You can do this by copying the `p` directory from your current Dgraph cluster into the new cluster, but you will need to perform an additional step before starting the Alpha nodes in the new cluster, as described below. 
 
 After starting your Zero nodes, you need to increase the Zero's timestamp by sending the following `curl` request to the Zero leader node:
 


### PR DESCRIPTION
This pr explains how to properly use a `p` directory that is coming from a different cluster. This adds instruction on how to let Zero correctly manage the `p` directory by increasing the timestamp