### PR TITLE
docs(clients): Add multi-tenancy example to C#

### DIFF
--- a/content/clients/csharp.md
+++ b/content/clients/csharp.md
@@ -30,6 +30,25 @@ Make a new client by passing in one or more GRPC channels pointing to alphas.
 var client = new DgraphClient(new Channel("127.0.0.1:9080", ChannelCredentials.Insecure));
 ```
 
+### Multi-tenancy
+
+In [multi-tenancy]({{< relref "multitenancy.md" >}}) environments, Dgraph provides a new method `LoginRequest()`,
+which will allow the users to login to a specific namespace.
+
+In order to create a Dgraph client, and make the client login into namespace `123`:
+
+```c#
+var lr = new Api.LoginRequest() {
+  UserId = "userId",
+  Password = "password",
+  Namespace = 123
+}
+client.Login(lr)
+```
+
+In the example above, the client logs into namespace `123` using username `userId` and password `password`.
+Once logged in, the client can perform all the operations allowed to the `userId` user of namespace `123`.
+
 ### Creating a Client for Slash GraphQL Endpoint
 
 If you want to connect to Dgraph running on your [Slash GraphQL](https://slash.dgraph.io) instance, then all you need is the URL of your Slash GraphQL endpoint and the API key. You can get a client using them as follows:


### PR DESCRIPTION
fixes DOC-217
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
