### PR TITLE
Docs (Chore): Update to reflect Windows and MacOS deprecation, include Docker standalone instructions

### DIFF
--- a/content/deploy/metrics.md
+++ b/content/deploy/metrics.md
@@ -85,7 +85,7 @@ holding from the operating system and how much is actively in use.
  -------                          | -----------
  `dgraph_memory_idle_bytes`       | Estimated amount of memory that is being held idle that could be reclaimed by the OS.
  `dgraph_memory_inuse_bytes`      | Total memory usage in bytes (sum of heap usage and stack usage).
- `dgraph_memory_proc_bytes`       | Total memory usage in bytes of the Dgraph process. On Linux/macOS, this metric is equivalent to resident set size. On Windows, this metric is equivalent to [Go's runtime.ReadMemStats](https://golang.org/pkg/runtime/#ReadMemStats).
+ `dgraph_memory_proc_bytes`       | Total memory usage in bytes of the Dgraph process. This metric is equivalent to resident set size on Linux.
 
 ## Raft leadership metrics
 

--- a/content/deploy/production-checklist.md
+++ b/content/deploy/production-checklist.md
@@ -35,8 +35,9 @@ Do not run multiple Dgraph Zeros or Dgraph Alpha processes on a single machine. 
 
 ### Operating System
 
-The recommended operating system is Linux for production workloads. Dgraph provides release binaries in Linux, macOS, and Windows. For test environments, you can choose to run Dgraph on any operating system. This deployment guide assumes you are setting up Dgraph on Linux systems (see [Operating System Tuning]({{< relref
-   "#operating-system-tuning" >}})).
+Dgraph is designed to run on Linux. As of release v21.03, Dgraph no longer
+supports installation on Windows or macOS. To run Dgraph on Windows
+and macOS, use the [standalone Docker image]({{<relref "dgraph-overview#to-run-dgraph-using-the-standalone-docker-image">}}).
 
 ### CPU and Memory
 

--- a/content/deploy/single-host-setup.md
+++ b/content/deploy/single-host-setup.md
@@ -8,6 +8,10 @@ weight = 6
 
 ## Run directly on the host
 
+You can run Dgraph directly on a single Linux host. As of release v21.03, Dgraph
+no longer supports installation on Windows or macOS. To run Dgraph on Windows
+and macOS, use the [standalone Docker image]({{<relref "dgraph-overview#to-run-dgraph-using-the-standalone-docker-image">}}).
+
 ### Run Dgraph zero
 
 ```sh
@@ -40,6 +44,11 @@ dgraph-ratel
 ```
 
 ## Run using Docker
+
+{{ notice "Note" }}
+As of release v21.03, Dgraph no longer supports installation on Windows or macOS.
+Windows and macOS users who want to evaluate Dgraph can use the [standalone Docker image]({{<relref "dgraph-overview#to-run-dgraph-using-the-standalone-docker-image">}}).
+{{ /notice}}
 
 Dgraph cluster can be setup running as containers on a single host. First, you'd want to figure out the host IP address. You can typically do that via
 

--- a/content/deploy/tls-configuration.md
+++ b/content/deploy/tls-configuration.md
@@ -63,7 +63,7 @@ $ dgraph cert ls
 ```
 
 The default location where the _cert_ command stores certificates (and keys) is
-`tls` under the Dgraph working directory. The default dir path can be overridden
+`tls` under the Dgraph working directory. The default directory path can be overridden
 using the `--dir` option. For example:
 
 ```sh
@@ -311,12 +311,12 @@ $ sudo update-ca-certificates`
 
 ##### Firefox
 
-* Goto Preferences -> Privacy & Security -> View Certificates -> Authorities
+* Choose Preferences -> Privacy & Security -> View Certificates -> Authorities
 * Click on Import and import the `ca.crt`
 
 ##### Chrome
 
-* Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Authorities
+* Choose Settings -> Privacy and Security -> Security -> Manage Certificates -> Authorities
 * Click on Import and import the `ca.crt`
 
 ### Step 3. Point Ratel to the `https://` endpoint of alpha server.
@@ -336,9 +336,9 @@ also need to install client certificate on your browser:
    ```
    Use any password you like for export, it is used to encrypt the p12 file.
 
-3. Import the client certificate to your browser. It can be done in chrome as follows:
-   * Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Your Certificates
-   * Click on Import and import the `laptopuser.p12`. For mac OS, this process returns back to KeyChain, and under the area "My Certificates" select `laptopuser.p12`.
+3. Import the client certificate to your browser. It can be done in Chrome as follows:
+   * Choose Settings -> Privacy and Security -> Security -> Manage Certificates -> Your Certificates
+   * Click on Import and import the `laptopuser.p12`.
 
 {{% notice "note" %}}
 Mutual TLS may not work in Firefox because Firefox is unable to send privately-signed client certificates, this issue is filed [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1662607).

--- a/content/deploy/tls-configuration.md
+++ b/content/deploy/tls-configuration.md
@@ -306,14 +306,6 @@ $ cp /path/to/ca.crt /usr/local/share/ca-certificates/ca.crt
 # Update the CA store
 $ sudo update-ca-certificates`
 ```
-##### Mac OS X
-```sh
-$ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ca.crt
-```
-##### Windows
-```sh
-$ certutil -addstore -f "ROOT" /path/to/ca.crt
-```
 
 ### Step 2. Install Dgraph Root CA into Web Browsers Trusted CA List
 
@@ -347,11 +339,7 @@ also need to install client certificate on your browser:
 3. Import the client certificate to your browser. It can be done in chrome as follows:
    * Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Your Certificates
    * Click on Import and import the `laptopuser.p12`. For mac OS, this process returns back to KeyChain, and under the area "My Certificates" select `laptopuser.p12`.
-<!-- Cut because we have cut macOS support 
-{{% notice "note" %}}
-Under macOS you can alternatively import the `.p12` file using the command line by `security import ./laptopuser.p12 -P secretPassword`.
-{{% /notice %}}
--->
+
 {{% notice "note" %}}
 Mutual TLS may not work in Firefox because Firefox is unable to send privately-signed client certificates, this issue is filed [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1662607).
 {{% /notice %}}

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -58,19 +58,21 @@ or [instructions for cluster setup]({{< relref "/deploy/multi-host-setup" >}}).
 {{% notice "Note" %}}
 Dgraph is designed to run on Linux. As of release v21.03, Dgraph no longer
 supports installation on Windows or macOS. We recommend using the standalone
-Docker image to try out Dgraph on macOS.
+Docker image to try out Dgraph on Windows or macOS.
 {{% /notice %}}
 
 #### To run Dgraph using the standalone Docker image
 
 1. Download docker: https://www.docker.com/
-2. Run the Dgraph Docker standalone image, as follows:
+2. Create a folder to store Dgraph data outside of the container (`mkdir -p ~/dgraph`)
+3. Run the Dgraph Docker standalone image, as follows:
 
-``` 
-  docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 \
-    -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph \
-    dgraph/standalone:v20.11.0
+```sh
+  docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph dgraph/standalone:v21.03
 ```  
+
+After following these steps, Dgraph Alpha now runs and listens for HTTP requests
+on port 8080, and Ratel listens on port 8000.
 
 ### Get started with fully-managed Dgraph
 

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -63,7 +63,7 @@ Docker image to try out Dgraph on Windows or macOS.
 
 #### To run Dgraph using the standalone Docker image
 
-1. Download docker: https://www.docker.com/
+1. Download [Docker](https://www.docker.com/)
 2. Create a folder to store Dgraph data outside of the container, as follows: `mkdir -p ~/dgraph`
 3. Get the Docker standalone image, as follows: `docker pull dgraph/standalone`
 4. Run the Dgraph Docker standalone image, as follows:
@@ -135,4 +135,3 @@ own Kubernetes (BYOK) environment.
 |server node|	A server that makes up part of a server cluster. See *Dgraph Alpha* and *Dgraph Zero*. |[Dgraph Cluster Setup documentation]({{< relref "/deploy/cluster-setup" >}}) |
 |predicate|	A property of a data node in a graph database; also a discrete piece of information available to request in a graph database.	| |
 |Slash GraphQL|	A fully-managed GraphQL database service powered by Dgraph database.	|[Slash GraphQL documentation]({{< relref "/slash-graphql" >}}) |
-

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -64,11 +64,12 @@ Docker image to try out Dgraph on Windows or macOS.
 #### To run Dgraph using the standalone Docker image
 
 1. Download docker: https://www.docker.com/
-2. Create a folder to store Dgraph data outside of the container (`mkdir -p ~/dgraph`)
-3. Run the Dgraph Docker standalone image, as follows:
+2. Create a folder to store Dgraph data outside of the container, as follows: `mkdir -p ~/dgraph`
+3. Get the Docker standalone image, as follows: `docker pull dgraph/standalone`
+4. Run the Dgraph Docker standalone image, as follows:
 
 ```sh
-  docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph dgraph/standalone:v21.03
+  docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph dgraph/standalone:v21.03.0
 ```  
 
 After following these steps, Dgraph Alpha now runs and listens for HTTP requests

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -37,11 +37,11 @@ You can run Dgraph database in a variety of ways:
 * Self-managed: You can use [Dgraph](https://dgraph.io/dgraph) on-premises, hosted on your own physical
 infrastructure. You can also run Dgraph in your AWS, GCP, or Azure cloud
 infrastructure.
-* Fully-managed (hosted): You can use Dgraph as a fully-managed cloud service.
-[Slash GraphQL](https://dgraph.io/graphql) gives you the power of Dgraph in a
-hosted service running on a shared cluster. [Dgraph Cloud](https://dgraph.io/cloud)
-extends Slash GraphQL to meet the needs of enterprises, and provides dedicated
-clusters. To learn more, see [Fully-Managed Dgraph](#fully-managed-dgraph).
+* Fully-managed (hosted): Dgraph Cloud provides Dgraph as a fully-managed cloud
+service. Dgraph Cloud [Shared Instances](https://dgraph.io/graphql)
+give you the power of Dgraph in a low-cost hosted service running on a shared cluster.
+Dgraph Cloud [Dedicated Instances](https://dgraph.io/cloud) provide an enterprise-grade
+service that runs on dedicated cluster instances. To learn more, see [Fully-Managed Dgraph](#fully-managed-dgraph).
 
 {{% notice "note" %}}
 The documentation provided on [this Dgraph Docs site](https://dgraph.io/docs)
@@ -55,9 +55,22 @@ to Slash GraphQL and Dgraph Cloud (except for content in the [Deploy and Manage]
 To run Dgraph on your own server, see [instructions for single-node setup]({{< relref "/deploy/single-host-setup" >}})
 or [instructions for cluster setup]({{< relref "/deploy/multi-host-setup" >}}).
 
-{{% notice "tip" %}}
-Dgraph Labs recommends running Dgraph on Linux for production use.
+{{% notice "Note" %}}
+Dgraph is designed to run on Linux. As of release v21.03, Dgraph no longer
+supports installation on Windows or macOS. We recommend using the standalone
+Docker image to try out Dgraph on macOS.
 {{% /notice %}}
+
+#### To run Dgraph using the standalone Docker image
+
+1. Download docker: https://www.docker.com/
+2. Run the Dgraph Docker standalone image, as follows:
+
+``` 
+  docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 \
+    -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph \
+    dgraph/standalone:v20.11.0
+```  
 
 ### Get started with fully-managed Dgraph
 

--- a/content/howto/completion.md
+++ b/content/howto/completion.md
@@ -77,10 +77,6 @@ Now open the `.bashrc` file with any text editor (you might need `sudo` to apply
 nano ~/.bashrc
 ```
 
-{{% notice "note" %}}
-macOS users using `bash` as the default shell need to configure `~/.bash_profile`.
-{{% /notice %}}
-
 Once opened, add the path to `dgraph-completion.sh` using the following syntax and save:
 
 ```sh

--- a/content/mutations/json-mutation-format.md
+++ b/content/mutations/json-mutation-format.md
@@ -8,8 +8,8 @@ weight = 10
 
 Mutations can also be specified using JSON objects. This can allow mutations to
 be expressed in a more natural way. It also eliminates the need for apps to
-have custom serialisation code, since most languages already have a JSON
-marshalling library.
+have custom serialization code, since most languages already have a JSON
+marshaling library.
 
 When Dgraph receives a mutation as a JSON object, it first converts it into an 
 internal edge format that is then processed into Dgraph.
@@ -20,7 +20,7 @@ internal edge format that is then processed into Dgraph.
 Each JSON object represents a single node in the graph.
 
 {{% notice "note" %}}
-JSON mutations are available via gRPC clients such as the Go client, JS client, and Java client, and are available to HTTP clients with [dgraph-js-http](https://github.com/dgraph-io/dgraph-js-http) and cURL. See more about cURL [here]({{< relref "#using-json-operations-via-curl" >}})
+JSON mutations are available via gRPC clients such as the Go client, JavaScript client, and Java client, and are available to HTTP clients with [dgraph-js-http](https://github.com/dgraph-io/dgraph-js-http) and cURL. See more about cURL [here]({{< relref "#using-json-operations-via-curl" >}})
 {{% /notice %}}
 
 ## Setting literal values
@@ -58,7 +58,7 @@ to the key `blank-0`. You could specify your own key like
 }
 ```
 
-In this case, the assigned uids map would have a key called `diggy` with the value being the uid
+In this case, the assigned UIDs map would have a key called `diggy` with the value being the uid
 assigned to it.
 
 ### Forbidden values
@@ -164,8 +164,8 @@ _:blank-0 <friend> _:blank-1 .
 _:blank-1 <name> "Betty" .
 ```
 
-The result of the mutation would contain the uids assigned to `blank-0` and `blank-1` nodes. If you
-wanted to return these uids under a different key, you could specify the `uid` field as a blank
+The result of the mutation would contain the UIDs assigned to `blank-0` and `blank-1` nodes. If you
+wanted to return these UIDs under a different key, you could specify the `uid` field as a blank
 node.
 
 ```JSON
@@ -293,8 +293,8 @@ _:blank-1 <dgraph.type> "Person" .
 
 Facets do not contain type information but Dgraph will try to guess a type from
 the input. If the value of a facet can be parsed to a number, it will be
-converted to either a float or an int. If it can be parsed as a boolean, it will
-be stored as a boolean. If the value is a string, it will be stored as a
+converted to either a float or an int. If it can be parsed as a Boolean, it will
+be stored as a Boolean. If the value is a string, it will be stored as a
 datetime if the string matches one of the time formats that Dgraph recognizes
 (YYYY, MM-YYYY, DD-MM-YYYY, RFC339, etc.) and as a double-quoted string
 otherwise. If you do not want to risk the chance of your facet data being

--- a/content/mutations/json-mutation-format.md
+++ b/content/mutations/json-mutation-format.md
@@ -496,7 +496,7 @@ with a `name`:
 
 This syntax can be used in the most current version of Ratel, in the [dgraph-js-http](https://github.com/dgraph-io/dgraph-js-http) client or even via cURL.
 
-You can also [download the Ratel UI for Linux, macOS, or Windows](https://discuss.dgraph.io/t/ratel-installer-for-linux-macos-and-windows-preview-version-ratel-update-from-v1-0-6/2884/).
+You can also [download the Ratel UI](https://discuss.dgraph.io/t/ratel-installer-for-linux-macos-and-windows-preview-version-ratel-update-from-v1-0-6/2884/).
 
 Mutate:
 ```JSON


### PR DESCRIPTION
Per DOC-141

Note that the docker standalone command was taken from the Tour (https://dgraph.io/tour/intro/2/), and was validated using the command shown there:
docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 \
  -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph \
  dgraph/standalone:v20.11.0
  
After validating this with 20.11.0, I updated it to reference v.21.03.0

Also includes manual spellcheck (`aspell check -M -x filename.md`) on all updated files

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a Jira issue, include "Fixes DGRAPH-###" or "Per Dgraph-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
