### PR TITLE
docs(flags): Add documentation for --raft superflag's changed options

### DIFF
--- a/content/deploy/cli-command-reference.md
+++ b/content/deploy/cli-command-reference.md
@@ -115,7 +115,8 @@ not shown here are unchanged in release v21.03.
 | `--idx` | int | `idx` | int |`alpha`, `zero`| Provides an optional Raft ID that an Alpha node can use to join Raft groups |
 | `--group` | int | `group` | int |`alpha`| Provides an optional Raft group ID that an Alpha node can use to request group membership from a Zero node |
 |  |  | (new)`learner` | bool | `alpha`, `zero`| Make this Alpha a learner node (used for read-only replicas) |
-| `--snapshot-after` | int | `snapshot-after` | bool |`alpha`|  Create a new Raft snapshot after the specified number of Raft entries |
+| | | (new)`snapshot-after-duration` | int |`alpha`|  Frequency at which Raft snapshots are created |
+| `--snapshot-after` | int | `snapshot-after-entries` | int |`alpha`|  Create a new Raft snapshot after the specified number of Raft entries |
 | | | **`--security`** | | | Security superflag |
 | `--auth_token` | string | `token` | string |`alpha`| Authentication token |
 | `--whitelist` | string | `whitelist` | string |`alpha`| A comma separated list of IP addresses, IP ranges, CIDR blocks, or hostnames for administration |

--- a/content/design-concepts/raft.md
+++ b/content/design-concepts/raft.md
@@ -115,8 +115,7 @@ and then add servers to the cluster one-by-one.{{% /notice %}}
 One of the ways to do this is snapshotting. As soon as the state machine is synced to disk, the
 logs can be discarded.
 
-Snapshots are taken by default after 10000 Raft entries. This number can be adjusted using the
-`dgraph alpha --snapshot_after` flag.
+Snapshots are taken by default after 10000 Raft entries, with a frequency of 30 minutes. The frequency indicates the time between two subsequent snapshots. These numbers can be adjusted using the `--raft` [superflag]({{< relref "deploy/cli-command-reference.md" >}})'s `snapshot-after-entries` and `snapshot-after-duration` options respectively. Snapshots are created only when conditions set by both of these options have been met.
 
 ## Clients
 Clients must locate the cluster to interact with it. Various approaches can be used for discovery.


### PR DESCRIPTION
* Adds documentation for the new `snapshot-after-duration` option of `--raft`
* Renaming of `snapshot-after` to `snapshot-after-entries`

As per [PR #7675](https://github.com/dgraph-io/dgraph/pull/7675).
Addresses [DOC-250](https://dgraph.atlassian.net/browse/DOC-250).