### PR TITLE
[Cherry-pick] Added double quotes on rdf format for facets (#183)

### DIFF
--- a/content/mutations/json-mutation-format.md
+++ b/content/mutations/json-mutation-format.md
@@ -284,9 +284,9 @@ used to show facets in query results. E.g.
 ```
 Produces the following RDFs:
 ```
-_:blank-0 <name> "Carol" (initial=C) .
+_:blank-0 <name> "Carol" (initial="C") .
 _:blank-0 <dgraph.type> "Person" .
-_:blank-0 <friend> _:blank-1 (close=yes) .
+_:blank-0 <friend> _:blank-1 (close="yes") .
 _:blank-1 <name> "Daryl" .
 _:blank-1 <dgraph.type> "Person" .
 ```


### PR DESCRIPTION
Added double quotes (`""`) for facet syntax in RDF. 

Wrong syntax:
```
_:blank-0 <name> "Carol" (initial=C) .
```
Correct syntax:
```
_:blank-0 <name> "Carol" (initial="C") .
```

(cherry picked from commit 9d6445a0e736d233cf4f6f063e345ea0e35c7180)

