### PR TITLE
Docs (Chore) Dependent on Merge Themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Making our documentation easy to understand includes optimizing it for client-si
 
 We use [Hugo](https://gohugo.io/) for our documentation. You can use Hugo to locally stage doc updates before or after creating a PR.
 
-1. Download and install the latest patch of hugo version v0.74.x from [here](https://github.com/gohugoio/hugo/releases/).
+1. Download and install the latest patch of hugo version v0.79.x from [here](https://github.com/gohugoio/hugo/releases/).
    ```bash
    pushd ~/Downloads
-   VERSION=v0.74
+   VERSION=v0.79
    TAG=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases | jq '.[].tag_name' -r | grep $VERSION | head -1)
    OS=$(uname -s)
    if [[ ${OS,,} == "darwin" ]]; then

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,9 @@ canonifyURLs = true
 languageCode = "en-us"
 theme = "hugo-docs"
 
+disableKinds = ["taxonomy"]
+ignoreErrors = ["error-disable-taxonomy"]
+
 [markup.goldmark.renderer]
 unsafe = true
 
@@ -26,3 +29,4 @@ title = "Dgraph Documentation"
 
 [params]
 discourse = "https://discuss.dgraph.io/"
+site = "dgraph-docs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,18 +5,18 @@
   ignore = "git diff --quiet HEAD^ HEAD ."
 
 [context.production.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.79.0"
   LOOP = "false"
 
 [context.deploy-preview]
   command = "./scripts/local.sh --preview $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.79.0"
   LOOP = "false"
   HOST = "/"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.79.0"
   LOOP = "false"
   HOST = "/"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,10 +24,7 @@ PUBLIC="${PUBLIC:-public}"
 LOOP="${LOOP:-true}"
 # Binary of hugo command to run.
 HUGO="${HUGO:-hugo}"
-OLD_THEME="${OLD_THEME:-old-theme}"
-NEW_THEME="${NEW_THEME:-master}"
-
-# those which have docs.
+THEME_BRANCH="${THEME_BRANCH:-master}"
 
 # Place the latest version at the beginning so that version selector can
 # append '(latest)' to the version string, followed by the master version,
@@ -42,19 +39,11 @@ MAJOR_VERSIONS=(
   $getMajorVersions
 )
 
-# these versions use new theme
-NEW_VERSIONS=(
+VERSIONS_ARRAY=(
   ${MAJOR_VERSIONS:0}
   'master'
   ${MAJOR_VERSIONS[@]:1}
 )
-
-# these versions use old theme
-OLD_VERSIONS=(
-  'v20.03'
-)
-
-VERSIONS_ARRAY=("${NEW_VERSIONS[@]}" "${OLD_VERSIONS[@]}")
 
 joinVersions() {
 	versions=$(printf ",%s" "${VERSIONS_ARRAY[@]}")
@@ -154,11 +143,11 @@ while true; do
 		[ ! -d 'themes/hugo-docs' ] && git clone https://github.com/dgraph-io/hugo-docs themes/hugo-docs
 	fi
 
-	# Lets check if the new theme was updated.
+	# Lets check if the theme was updated.
 	pushd themes/hugo-docs > /dev/null
 	git remote update > /dev/null
 	themeUpdated=1
-	if branchUpdated "${NEW_THEME}" ; then
+	if branchUpdated "${THEME_BRANCH}" ; then
 		echo -e "$(date) $GREEN Theme has been updated. Now will update the docs.$RESET"
 		themeUpdated=0
 	fi
@@ -167,30 +156,9 @@ while true; do
 	echo -e "$(date)  Starting to check branches."
 	git remote update > /dev/null
 
-	for version in "${NEW_VERSIONS[@]}"
+	for version in "${VERSIONS_ARRAY[@]}"
 	do
-	    latest_version=$(curl -s https://get.dgraph.io/latest | grep -o '"latest": *"[^"]*' | grep -o '[^"]*$'  | grep  "$version" | head -n1)
-		SETO="${latest_version:-master}" 
-		checkAndUpdate "$version" "$SETO"
-		echo "version => '$version'"
-		echo "latest_version => '$SETO'"
-		latest_version=''
-	done
-
-	# Lets check if the old theme was updated.
-	pushd themes/hugo-docs > /dev/null
-	themeUpdated=1
-	if branchUpdated "${OLD_THEME}" ; then
-		echo -e "$(date) $GREEN Theme has been updated. Now will update the docs.$RESET"
-		themeUpdated=0
-	fi
-	popd > /dev/null
-
-	git remote update > /dev/null
-
-	for version in "${OLD_VERSIONS[@]}"
-	do
-		latest_version=$(curl -s https://get.dgraph.io/latest | grep -o '"latest": *"[^"]*' | grep -o '[^"]*$'  | grep  "$version" | head -n1)
+	  latest_version=$(curl -s https://get.dgraph.io/latest | grep -o '"latest": *"[^"]*' | grep -o '[^"]*$'  | grep  "$version" | head -n1)
 		SETO="${latest_version:-master}" 
 		checkAndUpdate "$version" "$SETO"
 		echo "version => '$version'"
@@ -204,8 +172,8 @@ while true; do
 	popd > /dev/null
 
 	firstRun=0
-        if ! $LOOP; then
-            exit
-        fi
+  if ! $LOOP; then
+    exit
+  fi
 	sleep 60
 done


### PR DESCRIPTION
Drop Docs Build for EOL v20.03 per @danielmai 

Upgrade hugo to build with version 0.79.0

Add site param to hugo config for docs site repo

Add disableKinds and ignoreErrors to quiet hugo builds for unwanted taxonomy pages

This needs picked to: 
- `master`, 
- `release/v21.03`, 
-  `release/v20.11`, 
-  `release/v20.07`

Merging this PR is prep work for:
https://github.com/dgraph-io/hugo-docs/pull/97

This also drops 20.03 docs in the build script. Not sure if we want to add a redirect for existing links to v20.03 docs to a landing page that states what versions are supported instead of 404 pages.