### PR TITLE
Docs (chore) Fixing 404s

### DIFF
--- a/content/deploy/tls-configuration.md
+++ b/content/deploy/tls-configuration.md
@@ -11,7 +11,7 @@ addition, Dgraph can now secure gRPC communications between Dgraph Alpha and
 Dgraph Zero server nodes using mutual TLS (mTLS). Dgraph can now also secure
 communications over the Dgraph Zero `gRPC-external-private` port used by
 Dgraph's Live Loader and Bulk Loader clients. To learn more about the HTTP and
-gRPC ports used by Dgraph Alpha and Dgraph Zero, see [Ports Usage](ports-usage).
+gRPC ports used by Dgraph Alpha and Dgraph Zero, see [Ports Usage]({{< relref "deploy/ports-usage" >}}).
 Password-protected private keys are **not supported**.
 
 To further improve TLS security, only TLS v1.2 cypher suites that use 128-bit or

--- a/content/design-concepts/minimizing-network-calls.md
+++ b/content/design-concepts/minimizing-network-calls.md
@@ -16,7 +16,7 @@ In a distributed SQL/NoSQL database, this would require you to retrieve a lot of
 
 Method 1:
 
-* Find all the friends (~ 338 [friends](http://www.pewresearch.org/fact-tank/2014/02/03/6-new-facts-about-facebook/</ref>)).
+* Find all the friends (~ 338 [friends](https://www.pewresearch.org/fact-tank/2014/02/03/what-people-like-dislike-about-facebook/)).
 * Find all their friends (~ 338 * 338 = 40,000 people).
 * Find all the posts liked by these people over the last year (resulting set in millions).
 * Intersect these posts with posts authored by person X.

--- a/content/howto/jepsen-tests.md
+++ b/content/howto/jepsen-tests.md
@@ -22,12 +22,6 @@ This should start 5 Jepsen nodes in docker containers.
 
 3. Now ssh into `jepsen-control` container and run the tests.
 
-{{% notice "note" %}}
-You can use the [transfer](https://github.com/dgraph-io/dgraph/blob/master/contrib/nightly/transfer.sh) script to build the Dgraph binary and upload the tarball to https://transfer.sh, which gives you a URL that can then be used in the Jepsen tests (using --package-url flag).
-{{% /notice %}}
-
-
-
 ```sh
 docker exec -it jepsen-control bash
 ```

--- a/content/query-language/fragments.md
+++ b/content/query-language/fragments.md
@@ -7,7 +7,7 @@ weight = 25
 +++
 
 The `fragment` keyword lets you define new fragments that can be referenced
-in a query, per the [GraphQL specification](https://facebook.github.io/graphql/#sec-Language.Fragments).
+in a query, per the [Fragments section of the GraphQL specification](http://spec.graphql.org/June2018/#sec-Language.Fragments).
 Fragments allow for the reuse of common repeated selections of fields, reducing
 duplicated text in the DQL documents. Fragments can be nested inside fragments,
 but no cycles are allowed in such cases. For example:


### PR DESCRIPTION
Per DOC-274

Cherry-pick to 21.03 and 20.11
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
