### PR TITLE
Docs(Other): fix notice tag typo

### DIFF
--- a/content/deploy/single-host-setup.md
+++ b/content/deploy/single-host-setup.md
@@ -45,10 +45,10 @@ dgraph-ratel
 
 ## Run using Docker
 
-{{ notice "Note" }}
+{{% notice "note" %}}
 As of release v21.03, Dgraph no longer supports installation on Windows or macOS.
 Windows and macOS users who want to evaluate Dgraph can use the [standalone Docker image]({{<relref "dgraph-overview#to-run-dgraph-using-the-standalone-docker-image">}}).
-{{ /notice}}
+{{% /notice %}}
 
 Dgraph cluster can be setup running as containers on a single host. First, you'd want to figure out the host IP address. You can typically do that via
 

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -55,7 +55,7 @@ to Dgraph Cloud (except for content in the [Deploy and Manage]({{< relref "/depl
 To run Dgraph on your own server, see [instructions for single-node setup]({{< relref "/deploy/single-host-setup" >}})
 or [instructions for cluster setup]({{< relref "/deploy/multi-host-setup" >}}).
 
-{{% notice "Note" %}}
+{{% notice "note" %}}
 Dgraph is designed to run on Linux. As of release v21.03, Dgraph no longer
 supports installation on Windows or macOS. We recommend using the standalone
 Docker image to try out Dgraph on Windows or macOS.
@@ -72,7 +72,7 @@ Docker image to try out Dgraph on Windows or macOS.
   docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph dgraph/standalone:v21.03.0
 ```  
 
-{{% notice "Tip" %}}
+{{% notice "tip" %}}
 To run the Docker standalone image for another version of Dgraph, change `v21.03.0`
 in the command shown above to the version number for a previous release, such as `v20.11.0`.
 {{% /notice %}}


### PR DESCRIPTION
on https://dgraph.io/docs/deploy/single-host-setup/ the "Run using Docker" section has notice which is not rendered correctly due to typo. Refer to attached screenshot

<img width="1020" alt="Screen Shot 2021-04-25 at 10 32 03 AM" src="https://user-images.githubusercontent.com/612092/115981470-b1759680-a5b1-11eb-9b20-330727ab1727.png">
