### PR TITLE
Docs (Support): Clarify support policy for releases, communicate API / service support policy

### DIFF
--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -58,7 +58,8 @@ your Dgraph Cloud backend will switch to read-only.
 include breaking API changes or data format changes are handled as rolling upgrades,
 with no impact on HA clusters and a few minutes of downtime for non-HA clusters.
 
-<!-- Original API deprecation wording, for reviewer reference:  
+<!--
+Original API deprecation wording, for reviewer reference:  
 If there're API breaking changes, we'll give the user plenty of notice (months) and work with them to upgrade them to the new version — this might require code changes at their end, so we have to be more careful.
 
 If there're no API changes, but underlying data format changes, then we'd upgrade the user automatically based on the downtime slots the user chooses. Downtime for us means moving existing backend to "read-only" for 15-30 mins, and upgrading them.

--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -52,7 +52,7 @@ will provide advance notice to Dgraph customers so they can update their code
 to work with the breaking API change.
 * **Data format changes**: Occasionally, Dgraph Cloud service updates will include
 changes to the underlying data format. When this happens, Dgraph Labs will contact
-Dgraph Cloud customers to schedule a short upgrade window. During the upgrade,
+Dgraph Cloud customers to schedule an upgrade window. During the upgrade,
 your Dgraph Cloud backend will switch to read-only.
 * **Dgraph Cloud rolling upgrades**: Dgraph Cloud service updates that don't
 include breaking API changes or data format changes are handled as rolling upgrades,

--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -59,7 +59,7 @@ include breaking API changes or data format changes are handled as rolling upgra
 with no impact on HA clusters and minimal impact on non-HA clusters (non-HA
 clusters switch to read-only during the upgrade).
 
-<!-- Original API deprecation wording per Manish, for reviewer reference:  
+<!-- Original API deprecation wording, for reviewer reference:  
 If there're API breaking changes, we'll give the user plenty of notice (months) and work with them to upgrade them to the new version — this might require code changes at their end, so we have to be more careful.
 
 If there're no API changes, but underlying data format changes, then we'd upgrade the user automatically based on the downtime slots the user chooses. Downtime for us means moving existing backend to "read-only" for 15-30 mins, and upgrading them.

--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -19,9 +19,9 @@ To learn about the latest releases and other important announcements, watch the
 
 [Announce]: https://discuss.dgraph.io/c/announce
 
-## Release series
+## Dgraph release series
 
- Dgraph Release Series | Current Release | Supported? | First Release Date | End of life
+ Dgraph release series | Current release | Supported? | First release date | End of life
 -----------------------|-----------------|------------|--------------------|--------------
  v21.03.x              | [v21.03.0][]    | Yes        | March 2021         | March 2022
  v20.11.x              | [v20.11.0][]    | Yes        | December 2020      | December 2021
@@ -39,3 +39,30 @@ To learn about the latest releases and other important announcements, watch the
 [v1.2.8]: https://discuss.dgraph.io/t/dgraph-v1-2-8-release/11183
 [v1.1.1]: https://discuss.dgraph.io/t/dgraph-v1-1-1-release/5664
 [v1.0.18]: https://discuss.dgraph.io/t/dgraph-v1-0-18-release/5663
+
+## Dgraph support policy
+
+The following summarizes our approach to product and service support:
+ 
+* **Dgraph releases**: Dgraph Labs supports Dgraph releases for 12 months following the
+ first release date, until the applicable *End of life* date (see above).
+* **Breaking API changes**: Occasionally, a new Dgraph release or Dgraph Cloud
+service update will include breaking API changes. When this happens, Dgraph Labs
+will provide advance notice to Dgraph customers so they can update their code 
+to work with the breaking API change.
+* **Data format changes**: Occasionally, Dgraph Cloud service updates will include
+changes to the underlying data format. When this happens, Dgraph Labs will contact
+Dgraph Cloud customers to schedule a short upgrade window. During the upgrade,
+your Dgraph Cloud backend will switch to read-only.
+* **Dgraph Cloud rolling upgrades**: Dgraph Cloud service updates that don't
+include breaking API changes or data format changes are handled as rolling upgrades,
+with no impact on HA clusters and minimal impact on non-HA clusters (non-HA
+clusters switch to read-only during the upgrade).
+
+<!-- Original API deprecation wording per Manish, for reviewer reference:  
+If there're API breaking changes, we'll give the user plenty of notice (months) and work with them to upgrade them to the new version — this might require code changes at their end, so we have to be more careful.
+
+If there're no API changes, but underlying data format changes, then we'd upgrade the user automatically based on the downtime slots the user chooses. Downtime for us means moving existing backend to "read-only" for 15-30 mins, and upgrading them.
+
+If there're no underlying data changes, then we can just do a rolling upgrade, with no noticeable impact on HA clusters (but perhaps a couple of mins of downtime for non-HA clusters).
+-->

--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -56,8 +56,7 @@ Dgraph Cloud customers to schedule a short upgrade window. During the upgrade,
 your Dgraph Cloud backend will switch to read-only.
 * **Dgraph Cloud rolling upgrades**: Dgraph Cloud service updates that don't
 include breaking API changes or data format changes are handled as rolling upgrades,
-with no impact on HA clusters and minimal impact on non-HA clusters (non-HA
-clusters switch to read-only during the upgrade).
+with no impact on HA clusters and a few minutes of downtime for non-HA clusters.
 
 <!-- Original API deprecation wording, for reviewer reference:  
 If there're API breaking changes, we'll give the user plenty of notice (months) and work with them to upgrade them to the new version — this might require code changes at their end, so we have to be more careful.


### PR DESCRIPTION
This change clarifies our support policy for releases and communicates how we plan to handle breaking API changes, underlying data format changes, and rolling upgrades that don't impact APIs or the underlying data format.

Open issues:
- How much advance notice will we provide for breaking API changes (need to spell out our minimum that we'll commit to).
- How will we provide advance notice to customers about breaking API changes. Using Discuss, email communication, etc.?
-"Upgrade window": What can we commit to, in terms of how long the upgrade window is?
- "Switch to read-only": How soon will we be able to switch Dgraph Cloud backends to "read-only" during upgrades? Currently they are 100% offline for at least a few seconds during upgrades.
- What happens in the case of an outage? How quickly can customers expect resolution?

Fixes DOC-269
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
