### PR TITLE
Docs (Ratel): Link to instructions to clone and build locally, add "Ratel Overview"

### DIFF
--- a/content/deploy/single-host-setup.md
+++ b/content/deploy/single-host-setup.md
@@ -86,9 +86,15 @@ docker run -it -p 7081:7081 --network dgraph_default -p 8081:8081 -p 9081:9081 -
 Notice the use of -o for server2 to override the default ports for server2.
 
 ### Run Dgraph's Ratel UI
+
 ```sh
 docker run -it -p 8000:8000 --network dgraph_default dgraph/dgraph:{{< version >}} dgraph-ratel
 ```
+
+{{% notice "note" %}} As an alternative to running Ratel using Docker, you can
+clone and build Ratel using the [instructions
+from the Ratel repository on GitHub](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md).
+{{% /notice %}}
 
 ## Run using Docker Compose (On single AWS instance)
 

--- a/content/deploy/single-host-setup.md
+++ b/content/deploy/single-host-setup.md
@@ -87,14 +87,8 @@ Notice the use of -o for server2 to override the default ports for server2.
 
 ### Run Dgraph's Ratel UI
 
-```sh
-docker run -it -p 8000:8000 --network dgraph_default dgraph/dgraph:{{< version >}} dgraph-ratel
-```
-
-{{% notice "note" %}} As an alternative to running Ratel using Docker, you can
-clone and build Ratel using the [instructions
-from the Ratel repository on GitHub](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md).
-{{% /notice %}}
+Ratel provides data visualization and cluster management for Dgraph. To get started with Ratel, use it online with the [Dgraph Ratel Dashboard](https://play.dgraph.io) or clone and build Ratel using the [instructions
+from the Ratel repository on GitHub](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md). To learn more, see [Ratel Overview]({{< relref "/ratel/overview" >}}).
 
 ## Run using Docker Compose (On single AWS instance)
 

--- a/content/ratel/backups.md
+++ b/content/ratel/backups.md
@@ -3,7 +3,7 @@ date = "2020-31-08T19:35:35+11:00"
 title = "Backups"
 [menu.main]
     parent = "ratel"
-    weight = 5
+    weight = 6
 +++
 
 ## Backup

--- a/content/ratel/cluster.md
+++ b/content/ratel/cluster.md
@@ -3,7 +3,7 @@ date = "2020-31-08T19:35:35+11:00"
 title = "Cluster"
 [menu.main]
     parent = "ratel"
-    weight = 4
+    weight = 5
 +++
 
 ## Cluster Management

--- a/content/ratel/connection.md
+++ b/content/ratel/connection.md
@@ -3,7 +3,7 @@ date = "2020-31-08T19:35:35+11:00"
 title = "Connection"
 [menu.main]
     parent = "ratel"
-    weight = 1
+    weight = 2
 +++
 
 ## Recent Servers

--- a/content/ratel/console.md
+++ b/content/ratel/console.md
@@ -3,7 +3,7 @@ date = "2020-31-08T19:35:35+11:00"
 title = "Console"
 [menu.main]
     parent = "ratel"
-    weight = 2
+    weight = 3
 +++
 
 ## Query Panel

--- a/content/ratel/overview.md
+++ b/content/ratel/overview.md
@@ -1,0 +1,13 @@
++++
+title = "Ratel Overview"
+description = "Ratel is a tool for data visualization and cluster management that's designed from the ground-up to work with Dgraph. Clone and build Ratel to get started."
+[menu.main]
+    parent = "ratel"
+    weight = 1
++++
+
+Ratel is a tool for data visualization and cluster management that's designed
+from the ground-up to work with Dgraph.
+
+You can clone and build Ratel to get started using the [instructions
+from the Ratel repository on GitHub](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md).

--- a/content/ratel/overview.md
+++ b/content/ratel/overview.md
@@ -7,7 +7,13 @@ description = "Ratel is a tool for data visualization and cluster management tha
 +++
 
 Ratel is a tool for data visualization and cluster management that's designed
-from the ground-up to work with Dgraph.
+from the ground-up to work with Dgraph and [DQL]({{< relref "/query-language" >}}). You can use it for the following types of tasks:
 
-You can clone and build Ratel to get started using the [instructions
+* Connect to a backend and manage cluster settings (see [Connection]({{< relref "/ratel/connection" >}}))
+* Run DQL queries and mutations, and see results (see [Console]({{< relref "/ratel/console" >}}))
+* Update or replace your DQL schema, and drop data (see [Schema]({{< relref "/ratel/schema" >}}))
+* Get information on cluster nodes and remove nodes (see [Cluster]({{< relref "/ratel/cluster" >}}))
+* Backup your server if you are using self-managed Dgraph (see [Backup]({{< relref "/ratel/backups" >}}))
+
+To get started with Ratel, use it online with the [Dgraph Ratel Dashboard](https://play.dgraph.io) or clone and build Ratel using the [instructions
 from the Ratel repository on GitHub](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md).

--- a/content/ratel/schema.md
+++ b/content/ratel/schema.md
@@ -4,7 +4,7 @@ title = "Schema"
 [menu.main]
 	identifier = "schema-management"
     parent = "ratel"
-    weight = 3
+    weight = 4
 +++
 
 ## Predicate Section


### PR DESCRIPTION
A Dgraph user requested that we link from Dgraph Docs to instructions for cloning and building Ratel. This PR adds links to those instructions, removes a non-functional Docker command to run Ratel, and adds a Ratel overview.

Fixes DOC-280
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
