### PR TITLE
Docs (Chore) Dependent on Merge Themes (#186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,24 @@ Making our documentation easy to understand includes optimizing it for client-si
 
 We use [Hugo](https://gohugo.io/) for our documentation. You can use Hugo to locally stage doc updates before or after creating a PR.
 
-1. Download and install the latest patch of hugo version v0.69.x from [here](https://github.com/gohugoio/hugo/releases/).
-
+1. Download and install the latest patch of hugo version v0.79.x from [here](https://github.com/gohugoio/hugo/releases/).
+   ```bash
+   pushd ~/Downloads
+   VERSION=v0.79
+   TAG=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases | jq '.[].tag_name' -r | grep $VERSION | head -1)
+   OS=$(uname -s)
+   if [[ ${OS,,} == "darwin" ]]; then
+     PKG=hugo_${TAG##v}_macOS-64bit.tar.gz
+     curl -sLO https://github.com/gohugoio/hugo/releases/download/${TAG}/${PKG}
+     tar xvzf $PKG hugo
+     sudo mv hugo /usr/local/bin/
+   else
+     PKG=hugo_${TAG##v}_Linux-64bit.deb
+     curl -sLO https://github.com/gohugoio/hugo/releases/download/${TAG}/${PKG}
+     sudo apt install $PKG
+   fi
+   popd
+   ```
 2. Run the command below to get the theme.
 
 ```

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,9 @@ canonifyURLs = true
 languageCode = "en-us"
 theme = "hugo-docs"
 
+disableKinds = ["taxonomy"]
+ignoreErrors = ["error-disable-taxonomy"]
+
 [markup.goldmark.renderer]
 unsafe = true
 
@@ -26,3 +29,4 @@ title = "Dgraph Documentation"
 
 [params]
 discourse = "https://discuss.dgraph.io/"
+site = "dgraph-docs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,18 +5,18 @@
   ignore = "git diff --quiet HEAD^ HEAD ."
 
 [context.production.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.79.0"
   LOOP = "false"
 
 [context.deploy-preview]
   command = "./scripts/local.sh --preview $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.79.0"
   LOOP = "false"
   HOST = "/"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.79.0"
   LOOP = "false"
   HOST = "/"


### PR DESCRIPTION
* Chore: Dependent on Merge Themes

Drop Docs Build for EOL v20.03 per dmai

Upgrade hugo to build with version 0.79.0

Add site param to hugo config for docs site repo

Add disableKinds and ignoreErrors to quiet hugo builds for unwanted taxonomy pages

This needs picked to master, release/v21.03, release/v20.11, and release/v20.07

* update readme to change hugo version


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
