### PR TITLE
Docs(Unofficial Dgraph Clients): Add dqlx as unofficial client

### DIFF
--- a/content/clients/unofficial-clients.md
+++ b/content/clients/unofficial-clients.md
@@ -24,14 +24,14 @@ These third-party clients are contributed by the community and are not officiall
 - https://github.com/liveforeverx/dlex
 - https://github.com/ospaarmann/exdgraph
 
+## Go
+
+- https://github.com/fenos/dqlx
+
 ## JavaScript
 
 - https://github.com/ashokvishwakarma/dgraph-orm
 - https://github.com/gverse/gverse
-
-## Go
-
-- https://github.com/fenos/dqlx
 
 ## Rust
 


### PR DESCRIPTION
This PR adds a link for [dqlx](https://github.com/fenos/dqlx) in the Unofficial Dgraph Clients section