### PR TITLE
Docs (GraphQL) Document lambda authHeader

### DIFF
--- a/content/graphql/lambda/field.md
+++ b/content/graphql/lambda/field.md
@@ -14,12 +14,12 @@ For example, to define a lambda function for the `rank` and `bio` fields in `Aut
 
 ```graphql
 type Author {
-        id: ID!
-        name: String! @search(by: [hash, trigram])
-        dob: DateTime @search
-        reputation: Float @search
-        bio: String @lambda
-        rank: Int @lambda
+  id: ID!
+  name: String! @search(by: [hash, trigram])
+  dob: DateTime @search
+  reputation: Float @search
+  bio: String @lambda
+  rank: Int @lambda
 }
 ```
 
@@ -27,17 +27,17 @@ You can also define `@lambda` fields on interfaces:
 
 ```graphql
 interface Character {
-        id: ID!
-        name: String! @search(by: [exact])
-        bio: String @lambda
+  id: ID!
+  name: String! @search(by: [exact])
+  bio: String @lambda
 }
 
 type Human implements Character {
-        totalCredits: Float
+  totalCredits: Float
 }
 
 type Droid implements Character {
-        primaryFunction: String
+  primaryFunction: String
 }
 ```
 
@@ -69,10 +69,10 @@ const humanBio = ({parent: {name, totalCredits}}) => `My name is ${name}. I have
 const droidBio = ({parent: {name, primaryFunction}}) => `My name is ${name}. My primary function is ${primaryFunction}.`
 
 self.addGraphQLResolvers({
-    "Author.bio": authorBio,
-    "Character.bio": characterBio,
-    "Human.bio": humanBio,
-    "Droid.bio": droidBio
+  "Author.bio": authorBio,
+  "Character.bio": characterBio,
+  "Human.bio": humanBio,
+  "Droid.bio": droidBio
 })
 ```
 
@@ -80,17 +80,17 @@ Another example, adding a resolver for `rank` using a `graphql` call:
 
 ```javascript
 async function rank({parents}) {
-    const idRepList = parents.map(function (parent) {
-        return {id: parent.id, rep: parent.reputation}
-    });
-    const idRepMap = {};
-    idRepList.sort((a, b) => a.rep > b.rep ? -1 : 1)
-        .forEach((a, i) => idRepMap[a.id] = i + 1)
-    return parents.map(p => idRepMap[p.id])
+  const idRepList = parents.map(function (parent) {
+    return {id: parent.id, rep: parent.reputation}
+  });
+  const idRepMap = {};
+  idRepList.sort((a, b) => a.rep > b.rep ? -1 : 1)
+    .forEach((a, i) => idRepMap[a.id] = i + 1)
+  return parents.map(p => idRepMap[p.id])
 }
 
 self.addMultiParentGraphQLResolvers({
-    "Author.rank": rank
+  "Author.rank": rank
 })
 ```
 

--- a/content/graphql/lambda/field.md
+++ b/content/graphql/lambda/field.md
@@ -24,7 +24,7 @@ type Author {
 }
 ```
 
-You can also define `@lambda` fields on interfaces:
+You can also define `@lambda` fields on interfaces, as follows:
 
 ```graphql
 interface Character {
@@ -44,7 +44,7 @@ type Droid implements Character {
 
 ### Resolvers
 
-Once the schema is ready, you can define your JavaScript mutation function and add it as a resolver in your JS source code. 
+After the schema is ready, you can define your JavaScript mutation function and add it as a resolver in your JS source code. 
 To add the resolver you can use either the `addGraphQLResolvers` or `addMultiParentGraphQLResolvers` methods.
 
 {{% notice "note" %}}
@@ -95,8 +95,8 @@ self.addMultiParentGraphQLResolvers({
 })
 ```
 
-The following example demonstrates using the client-provided JWT to return true if the custom claim
-for `USER` from the JWT matches the Author's `id`.`
+The following example demonstrates using the client-provided JWT to return `true` if the custom claim
+for `USER` from the JWT matches the `id` of the `Author`.
 
 ```javascript
 async function isMe({ parent, authHeader }) {
@@ -119,7 +119,7 @@ self.addGraphQLResolvers({
 
 ### Example
 
-If you execute this GraphQL query
+For example, if you execute the following GraphQL query:
 
 ```graphql
 query {
@@ -132,7 +132,7 @@ query {
 }
 ```
 
-You should see a response such as
+...you should see a response such as the following:
 
 ```json
 {
@@ -147,7 +147,7 @@ You should see a response such as
 }
 ```
 
-In the same way, if you execute this GraphQL query on the `Character` interface
+In the same way, if you execute the following GraphQL query on the `Character` interface:
 
 ```graphql
 query {
@@ -158,7 +158,7 @@ query {
 }
 ```
 
-You should see a response such as
+...you should see a response such as the following:
 
 ```json
 {
@@ -175,9 +175,11 @@ You should see a response such as
 }
 ```
 
-Note that the `Human` and `Droid` types will inherit the `bio` lambda field from the `Character` interface. 
+{{% notice "Note" %}}
+The `Human` and `Droid` types will inherit the `bio` lambda field from the `Character` interface. 
+{{% /notice %}}
 
-For example, if you execute a `queryHuman` query with a selection set containing `bio`, then the lambda function registered for `Human.bio` will be executed:
+For example, if you execute a `queryHuman` query with a selection set containing `bio`, then the lambda function registered for `Human.bio` is executed, as follows:
 
 ```graphql
 query {
@@ -188,7 +190,7 @@ query {
 }
 ```
 
-Response:
+This query generates the following response:
 
 ```json
 {

--- a/content/graphql/lambda/overview.md
+++ b/content/graphql/lambda/overview.md
@@ -34,8 +34,8 @@ There are three places where you can use the `@lambda` directive and thus tell D
 
 ```graphql
 type MyType {
-    ...
-    customField: String @lambda
+  ...
+  customField: String @lambda
 }
 ```
 
@@ -43,7 +43,7 @@ type MyType {
 
 ```graphql
 type Query {
-    myCustomQuery(...): QueryResultType @lambda
+  myCustomQuery(...): QueryResultType @lambda
 }
 ```
 
@@ -51,7 +51,7 @@ type Query {
 
 ```graphql
 type Mutation {
-    myCustomMutation(...): MutationResult @lambda
+  myCustomMutation(...): MutationResult @lambda
 }
 ```
 
@@ -112,7 +112,7 @@ In the following example, the resolver function `myTypeResolver` registered for 
 const myTypeResolver = ({parent: {customField}}) => `My value is ${customField}.`
 
 self.addGraphQLResolvers({
-    "MyType.customField": myTypeResolver
+  "MyType.customField": myTypeResolver
 })
 ```
 
@@ -176,10 +176,10 @@ In the following example, the resolver function `rank()` registered for the `ran
 
 ```graphql
 type Author {
-    id: ID!
-    name: String! @search(by: [hash, trigram])
-    reputation: Float @search
-    rank: Int @lambda
+  id: ID!
+  name: String! @search(by: [hash, trigram])
+  reputation: Float @search
+  rank: Int @lambda
 }
 ```
 
@@ -190,13 +190,13 @@ import { sortBy } from 'lodash';
 This function computes the rank of each author based on the reputation of the author relative to other authors.
 */
 async function rank({parents}) {
-    const idRepMap = {};
-    sortBy(parents, 'reputation').forEach((parent, i) => idRepMap[parent.id] = parents.length - i)
-    return parents.map(p => idRepMap[p.id])
+  const idRepMap = {};
+  sortBy(parents, 'reputation').forEach((parent, i) => idRepMap[parent.id] = parents.length - i)
+  return parents.map(p => idRepMap[p.id])
 }
 
 self.addMultiParentGraphQLResolvers({
-    "Author.rank": rank
+  "Author.rank": rank
 })
 ```
 
@@ -224,9 +224,9 @@ If you execute this lambda query
 
 ```graphql
 query {
-	queryMyType {
-		customField
-	}
+  queryMyType {
+    customField
+  }
 }
 ```
 
@@ -234,11 +234,11 @@ You should see a response such as
 
 ```json
 {
-	"queryMyType": [
-		{
-			"customField":"My value is Lambda Example"
-		}
-	]
+  "queryMyType": [
+    {
+      "customField":"My value is Lambda Example"
+    }
+  ]
 }
 ```
 

--- a/content/graphql/lambda/overview.md
+++ b/content/graphql/lambda/overview.md
@@ -10,9 +10,9 @@ weight = 1
 
 Lambda provides a way to write your custom logic in JavaScript, integrate it with your GraphQL schema, and execute it using the GraphQL API in a few easy steps:
 
-- Setup a Dgraph cluster with a working lambda server (not required for [Dgraph Cloud](https://dgraph.io/cloud) users)
-- Declare lambda queries, mutations, and fields in your GraphQL schema as needed
-- Define lambda resolvers for them in a JavaScript file
+1. Set up a Dgraph cluster with a working lambda server (not required for [Dgraph Cloud](https://dgraph.io/cloud) users)
+2. Declare lambda queries, mutations, and fields in your GraphQL schema as needed
+3. Define lambda resolvers for them in a JavaScript file
 
 This also simplifies the job of developers, as they can build a complex backend that is rich with business logic, without setting up multiple different services. Also, you can build your backend in JavaScript, which means you can build both your frontend and backend using the same language.
 
@@ -30,7 +30,7 @@ If you're using [Dgraph Cloud](https://dgraph.io/cloud), the final compiled scri
 
 There are three places where you can use the `@lambda` directive and thus tell Dgraph where to apply custom JavaScript logic.
 
-1. You can add lambda fields to your types and interfaces
+- You can add lambda fields to your types and interfaces, as follows:
 
 ```graphql
 type MyType {
@@ -39,7 +39,7 @@ type MyType {
 }
 ```
 
-2. You can add lambda queries to the Query type
+- You can add lambda queries to the Query type, as follows:
 
 ```graphql
 type Query {
@@ -47,7 +47,7 @@ type Query {
 }
 ```
 
-3. You can add lambda mutations to the Mutation type
+- You can add lambda mutations to the Mutation type, as follows:
 
 ```graphql
 type Mutation {
@@ -220,7 +220,7 @@ self.addMultiParentGraphQLResolvers({
 Scripts containing import packages (such as the example above) require compilation using Webpack.
 {{% /notice %}}
 
-A resolver example using a `dql` call:
+The following example resolver uses a `dql` call:
 
 ```javascript
 async function reallyComplexDql({parents, dql}) {
@@ -234,7 +234,7 @@ self.addMultiParentGraphQLResolvers({
 })
 ```
 
-A resolver example using a `graphql` call and manually overriding the authHeader provided by the client:
+The following resolver example uses a `graphql` call and manually overrides the `authHeader` provided by the client:
 
 ```javascript
 async function secretGraphQL({ parents, graphql }) {
@@ -272,7 +272,7 @@ self.addMultiParentGraphQLResolvers({
 
 ## Example
 
-If you execute this lambda query
+For example, if you execute the following lambda query:
 
 ```graphql
 query {
@@ -282,7 +282,7 @@ query {
 }
 ```
 
-You should see a response such as
+...you should see a response such as the following:
 
 ```json
 {
@@ -296,7 +296,7 @@ You should see a response such as
 
 ## Learn more
 
-Find out more about the  `@lambda` directive here:
+To learn more about the `@lambda` directive, see:
 
 * [Lambda fields](/graphql/lambda/field)
 * [Lambda queries](/graphql/lambda/query)

--- a/content/graphql/lambda/overview.md
+++ b/content/graphql/lambda/overview.md
@@ -76,6 +76,8 @@ Available only for types and interfaces (`null` for queries and mutations)
 - `args`,  the set of arguments for lambda queries and mutations
 - `graphql`, a function to execute auto-generated GraphQL API calls from the lambda server. The user's auth header is passed back to the `graphql` function, so this can be used securely
 - `dql`, provides an API to execute DQL from the lambda server
+- `authHeader`, provides the JWT key and value of the auth header passed from
+  the client
 
 The `addGraphQLResolvers` can be represented with the following TypeScript types:
 
@@ -142,6 +144,8 @@ This method takes an object as an argument, which maps a resolver name to the re
 - `args`,  the set of arguments for lambda queries and mutations (`null` for types and interfaces)
 - `graphql`, a function to execute auto-generated GraphQL API calls from the lambda server
 - `dql`, provides an API to execute DQL from the lambda server
+- `authHeader`, provides the JWT key and value of the auth header passed from
+  the client
 
 The `addMultiParentGraphQLResolvers` can be represented with the following TypeScript types:
 

--- a/content/graphql/lambda/overview.md
+++ b/content/graphql/lambda/overview.md
@@ -83,18 +83,24 @@ The `addGraphQLResolvers` can be represented with the following TypeScript types
 
 ```TypeScript
 type GraphQLResponse {
-  data?: Record<string, any>,
-  errors?: { message: string }[],
+  data?: Record<string, any>
+  errors?: { message: string }[]
+}
+
+type AuthHeader {
+  key: string
+  value: string
 }
 
 type GraphQLEventWithParent = {
-  parent: Record<string, any> | null,
-  args: Record<string, any>,
-  graphql: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>,
+  parent: Record<string, any> | null
+  args: Record<string, any>
+  graphql: (query: string, vars?: Record<string, any>, authHeader?: AuthHeader) => Promise<GraphQLResponse>
   dql: {
-    query: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>
-    mutate: (s: string) => Promise<GraphQLResponse>
-  },
+    query: (dql: string, vars?: Record<string, any>) => Promise<GraphQLResponse>
+    mutate: (dql: string) => Promise<GraphQLResponse>
+  }
+  authHeader: AuthHeader
 }
 
 function addGraphQLResolvers(resolvers: {
@@ -151,18 +157,24 @@ The `addMultiParentGraphQLResolvers` can be represented with the following TypeS
 
 ```TypeScript
 type GraphQLResponse {
-  data?: Record<string, any>,
+  data?: Record<string, any>
   errors?: { message: string }[]
 }
 
+type AuthHeader {
+  key: string
+  value: string
+}
+
 type GraphQLEventWithParents = {
-  parents: (Record<string, any>)[] | null,
-  args: Record<string, any>,
-  graphql: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>,
+  parents: (Record<string, any>)[] | null
+  args: Record<string, any>
+  graphql: (query: string, vars?: Record<string, any>, authHeader?: AuthHeader) => Promise<GraphQLResponse>
   dql: {
-    query: (s: string, vars: Record<string, any> | undefined) => Promise<GraphQLResponse>
-    mutate: (s: string) => Promise<GraphQLResponse>
-  },
+    query: (dql: string, vars?: Record<string, any>) => Promise<GraphQLResponse>
+    mutate: (dql: string) => Promise<GraphQLResponse>
+  }
+  authHeader: AuthHeader
 }
 
 function addMultiParentGraphQLResolvers(resolvers: {
@@ -208,7 +220,7 @@ self.addMultiParentGraphQLResolvers({
 Scripts containing import packages (such as the example above) require compilation using Webpack.
 {{% /notice %}}
 
-Another resolver example using a `dql` call:
+A resolver example using a `dql` call:
 
 ```javascript
 async function reallyComplexDql({parents, dql}) {
@@ -220,6 +232,42 @@ async function reallyComplexDql({parents, dql}) {
 self.addMultiParentGraphQLResolvers({
   "MyType.reallyComplexProperty": reallyComplexDql
 })
+```
+
+A resolver example using a `graphql` call and manually overriding the authHeader provided by the client:
+
+```javascript
+async function secretGraphQL({ parents, graphql }) {
+  const ids = parents.map((p) => p.id);
+  const secretResults = await graphql(
+    `query myQueryName ($ids: [ID!]) {
+      queryMyType(filter: { id: $ids }) {
+        id
+        controlledEdge { 
+          myField
+        }
+      }
+    }`,
+    { ids },
+    {
+      key: 'X-My-App-Auth'
+      value: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL215LmFwcC5pby9qd3QvY2xhaW1zIjp7IlVTRVIiOiJmb28ifSwiZXhwIjoxODAwMDAwMDAwLCJzdWIiOiJ0ZXN0IiwibmFtZSI6IkpvaG4gRG9lIDIiLCJpYXQiOjE1MTYyMzkwMjJ9.wI3857KzwjtZAtOjng6MnzKVhFSqS1vt1SjxUMZF4jc'
+    }
+  );
+  return parents.map((parent) => {
+    const secretRes = secretResults.data.find(res => res.id === parent.id)
+    parent.secretProperty = null
+    if (secretRes) {
+      if (secretRes.controlledEdge) {
+        parent.secretProperty = secretRes.controlledEdge.myField
+      }
+    }
+    return parent
+  });
+}
+self.addMultiParentGraphQLResolvers({
+  "MyType.secretProperty": secretGraphQL,
+});
 ```
 
 ## Example


### PR DESCRIPTION
Repairing PR from #127 since that original branch was deleted from a forked repo and could no longer modify it.

- add authHeader example for returning Boolean `Author.isMe`
- normalize indentation of files changed
- add `authHeader` definition including TS definitions in lambda overview
- add example for calling `graphql` function in lambda with custom authHeader (JWT)
- fixed TS syntax
- clarified some of the TS variables using longer names such as replacing `s` with `query` where the string is a query string and there is no need for smaller verbosity in documentation.