### PR TITLE
docs(graphql): Add note regarding lambda mutation prefixes

### DIFF
--- a/content/graphql/lambda/mutation.md
+++ b/content/graphql/lambda/mutation.md
@@ -11,7 +11,7 @@ weight = 4
 To set up a lambda mutation, first you need to define it on your GraphQL schema by using the `@lambda` directive.
 
 {{% notice "note" %}}
-`add` and `update` are reserved prefixes and they can't be used to define Lambda mutations.
+`add`, `update`, and `delete` are reserved prefixes and they can't be used to define Lambda mutations.
 {{% /notice %}}
 
 For example, to define a lambda mutation for `Author` that creates a new author with a default `reputation` of `3.0` given just the `name`:

--- a/content/graphql/lambda/mutation.md
+++ b/content/graphql/lambda/mutation.md
@@ -10,6 +10,10 @@ weight = 4
 
 To set up a lambda mutation, first you need to define it on your GraphQL schema by using the `@lambda` directive.
 
+{{% notice "note" %}}
+`add` and `update` are reserved prefixes and they can't be used to define Lambda mutations.
+{{% /notice %}}
+
 For example, to define a lambda mutation for `Author` that creates a new author with a default `reputation` of `3.0` given just the `name`:
 
 ```graphql

--- a/content/graphql/lambda/query.md
+++ b/content/graphql/lambda/query.md
@@ -10,6 +10,10 @@ weight = 3
 
 To set up a lambda query, first you need to define it on your GraphQL schema by using the `@lambda` directive.
 
+{{% notice "note" %}}
+`get`, `query`, and `aggregate` are reserved prefixes and they can't be used to define Lambda queries.
+{{% /notice %}}
+
 For example, to define a lambda query for `Author` that finds out authors given an author's `name`:
 
 ```graphql

--- a/content/graphql/schema/reserved.md
+++ b/content/graphql/schema/reserved.md
@@ -40,4 +40,16 @@ For each type, Dgraph generates a number of GraphQL types needed to operate the 
 - `UpdateAuthorPayload`
 - `AuthorAggregateResult`
 
+**Mutations**
+
+- `addAuthor`
+- `updateAuthor`
+- `deleteAuthor`
+
+**Queries**
+
+- `getAuthor`
+- `queryAuthor`
+- `aggregateAuthor`
+
 Thus if `Author` is present in the input schema, all of those become reserved type names.


### PR DESCRIPTION
Fixes DOC-196

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
