### PR TITLE
Update build.sh to move 'master' to the end of the list of build versions

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,8 +41,8 @@ MAJOR_VERSIONS=(
 
 VERSIONS_ARRAY=(
   ${MAJOR_VERSIONS:0}
-  'master'
   ${MAJOR_VERSIONS[@]:1}
+  'master'
 )
 
 joinVersions() {


### PR DESCRIPTION
Per CTO feedback, "master" should be the last entry in the version selector on dgraph.io/docs