### PR TITLE
DOCS (chore) add CURRENT_LATEST_TAG variable to local (preview) builds

### DIFF
--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -27,6 +27,8 @@ run() {
   export VERSIONS=${VERSION_STRING} \
   export CURRENT_BRANCH="master" \
   export CURRENT_VERSION=${CURRENT_VERSION}
+  latest_version=$(curl -s https://get.dgraph.io/latest | grep -o '"latest": *"[^"]*' | grep -o '[^"]*$'  | grep  "$version" | head -n1)
+  export CURRENT_LATEST_TAG="${latest_version:-master}"
 
   pushd "$(dirname "$0")/.." > /dev/null
   pushd themes > /dev/null


### PR DESCRIPTION
This gets the latest version for local and preview builds. Before this version tag was being set in the build script, but a preview deployment or local build using the local.sh script was not adding in the version variable needed for the version shortcode.