### PR TITLE
Docs (DQL) add multiple var blocks example

### DIFF
--- a/content/query-language/multiple-query-blocks.md
+++ b/content/query-language/multiple-query-blocks.md
@@ -1,18 +1,17 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
-title = "Multiple Query Blocks"
+title = "Multiple Query Blocks with DQL"
+description = "With Dgraph Query Language (DQL), you can include multiple query blocks in a single query, and have those query blocks execute in parallel."
 weight = 8
 [menu.main]
     parent = "query-language"
 +++
 
-Inside a single query, multiple query blocks are allowed.  The result is all blocks with corresponding block names.
+Inside a single query, multiple query blocks are allowed, and each block can 
+have a name. Multiple query blocks are executed in parallel, and they don't
+need to be related in any way.
 
-Multiple query blocks are executed in parallel.
-
-The blocks need not be related in any way.
-
-Query Example: All of Angelina Jolie's films, with genres, and Peter Jackson's films since 2008.
+Query Example: _"All of Angelina Jolie's films, with genres, and Peter Jackson's films since 2008"_
 
 {{< runnable >}}
 {
@@ -40,7 +39,10 @@ Query Example: All of Angelina Jolie's films, with genres, and Peter Jackson's f
 
 If queries contain some overlap in answers, the result sets are still independent.
 
-Query Example: The movies Mackenzie Crook has acted in and the movies Jack Davenport has acted in.  The results sets overlap because both have acted in the Pirates of the Caribbean movies, but the results are independent and both contain the full answers sets.
+Query Example: _"The movies Mackenzie Crook has acted in and the movies Jack Davenport has acted in"_
+
+The results sets overlap because both have acted in the _Pirates of the Caribbean_
+movies, but the results are independent and both contain the full answers sets.
 
 {{< runnable >}}
 {
@@ -73,11 +75,12 @@ Query Example: The movies Mackenzie Crook has acted in and the movies Jack Daven
 {{< /runnable >}}
 
 
-## Var Blocks
+## Variable (Var) Blocks
 
-Var blocks start with the keyword `var` and are not returned in the query results.
+Variable blocks (var blocks) start with the keyword `var` and are not returned
+in the query results, but do affect the contents of query results.
 
-Query Example: Angelina Jolie's movies ordered by genre.
+Query Example: _"Angelina Jolie's movies ordered by genre"_
 
 {{< runnable >}}
 {
@@ -101,11 +104,11 @@ Query Example: Angelina Jolie's movies ordered by genre.
 
 ## Multiple Var Blocks
 
-Multiple var blocks are also supported within a single query operation. Variables
-from one var block can be used in any of the following blocks but not within the
+You can also use multiple var blocks within a single query operation. Variables
+from one var block can be used in any of the following blocks, but not within the
 same block.
 
-Query Example: Movies containing both Angelina Jolie and Morgan Freeman sorted by name.
+Query Example: _"Movies containing both Angelina Jolie and Morgan Freeman, sorted by name"_
 
 {{< runnable >}}
 {
@@ -129,8 +132,8 @@ Query Example: Movies containing both Angelina Jolie and Morgan Freeman sorted b
 {{< /runnable >}}
 
 {{% notice "note" %}}
-This same results could have been obtained by logically combining both both var blocks
-in the films block.
+You could get the same query results by logically combining both both var blocks
+in the films block, as follows:
 ```
 {
   var(func:allofterms(name@en, "angelina jolie")) {
@@ -150,7 +153,7 @@ in the films block.
   }
 }
 ```
-The root `uid` function unions the uids from var `A` and `B` hence the need for the filter
-to intersect the uids from var `A` and `B`.
+The root `uid` function unions the `uid`s from var `A` and `B`, so you need a
+filter to intersect the `uid`s from var `A` and `B`.
 {{% /notice %}}
 

--- a/content/query-language/multiple-query-blocks.md
+++ b/content/query-language/multiple-query-blocks.md
@@ -99,3 +99,58 @@ Query Example: Angelina Jolie's movies ordered by genre.
 }
 {{< /runnable >}}
 
+## Multiple Var Blocks
+
+Multiple var blocks are also supported within a single query operation. Variables
+from one var block can be used in any of the following blocks but not within the
+same block.
+
+Query Example: Movies containing both Angelina Jolie and Morgan Freeman sorted by name.
+
+{{< runnable >}}
+{
+  var(func:allofterms(name@en, "angelina jolie")) {
+    name@en
+    actor.film {
+      A AS performance.film
+    }
+  }
+  var(func:allofterms(name@en, "morgan freeman")) {
+    name@en
+    actor.film {
+      B as performance.film @filter(uid(A))
+    }
+  }
+  
+  films(func: uid(B), orderasc: name@en) {
+    name@en
+  }
+}
+{{< /runnable >}}
+
+{{% notice "note" %}}
+This same results could have been obtained by logically combining both both var blocks
+in the films block.
+```
+{
+  var(func:allofterms(name@en, "angelina jolie")) {
+    name@en
+    actor.film {
+      A AS performance.film
+    }
+  }
+  var(func:allofterms(name@en, "morgan freeman")) {
+    name@en
+    actor.film {
+      B as performance.film
+    }
+  }
+  films(func: uid(A,B), orderasc: name@en) @filter(uid(A) AND uid(B)) {
+    name@en
+  }
+}
+```
+The root `uid` function unions the uids from var `A` and `B` hence the need for the filter
+to intersect the uids from var `A` and `B`.
+{{% /notice %}}
+

--- a/content/query-language/multiple-query-blocks.md
+++ b/content/query-language/multiple-query-blocks.md
@@ -4,6 +4,7 @@ title = "Multiple Query Blocks with DQL"
 description = "With Dgraph Query Language (DQL), you can include multiple query blocks in a single query, and have those query blocks execute in parallel."
 weight = 8
 [menu.main]
+    name = "Multiple Query Blocks"
     parent = "query-language"
 +++
 
@@ -75,7 +76,7 @@ movies, but the results are independent and both contain the full answers sets.
 {{< /runnable >}}
 
 
-## Variable (Var) Blocks
+## Variable (`var`) blocks
 
 Variable blocks (var blocks) start with the keyword `var` and are not returned
 in the query results, but do affect the contents of query results.
@@ -102,7 +103,7 @@ Query Example: _"Angelina Jolie's movies ordered by genre"_
 }
 {{< /runnable >}}
 
-## Multiple Var Blocks
+## Multiple `var` blocks
 
 You can also use multiple `var` blocks within a single query operation. You can
 use variables from one `var` block in any of the subsequent blocks, but not
@@ -131,7 +132,9 @@ Query Example: _"Movies containing both Angelina Jolie and Morgan Freeman sorted
 }
 {{< /runnable >}}
 
-{{% notice "note" %}}
+
+### Combining multiple `var` blocks
+
 You could get the same query results by logically combining both both var blocks
 in the films block, as follows:
 ```
@@ -155,4 +158,4 @@ in the films block, as follows:
 ```
 The root `uid` function unions the `uid`s from var `A` and `B`, so you need a
 filter to intersect the `uid`s from var `A` and `B`.
-{{% /notice %}}
+

--- a/content/query-language/multiple-query-blocks.md
+++ b/content/query-language/multiple-query-blocks.md
@@ -78,7 +78,7 @@ movies, but the results are independent and both contain the full answers sets.
 
 ## Variable (`var`) blocks
 
-Variable blocks (var blocks) start with the keyword `var` and are not returned
+Variable blocks (`var` blocks) start with the keyword `var` and are not returned
 in the query results, but do affect the contents of query results.
 
 Query Example: _"Angelina Jolie's movies ordered by genre"_
@@ -135,7 +135,7 @@ Query Example: _"Movies containing both Angelina Jolie and Morgan Freeman sorted
 
 ### Combining multiple `var` blocks
 
-You could get the same query results by logically combining both both var blocks
+You could get the same query results by logically combining both both `var` blocks
 in the films block, as follows:
 ```
 {
@@ -156,6 +156,6 @@ in the films block, as follows:
   }
 }
 ```
-The root `uid` function unions the `uid`s from var `A` and `B`, so you need a
-filter to intersect the `uid`s from var `A` and `B`.
+The root `uid` function unions the `uid`s from `var` `A` and `B`, so you need a
+filter to intersect the `uid`s from `var` `A` and `B`.
 


### PR DESCRIPTION
add example for multiple var blocks in single query, and add notice of alternative way to combine var blocks


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
