### PR TITLE
Docs (GraphQL) fix nested filter syntax error

### DIFF
--- a/content/graphql/queries/and-or-not.md
+++ b/content/graphql/queries/and-or-not.md
@@ -66,8 +66,12 @@ queryPost(filter: {
 } ) { ... }
 ```
 
-{{% notice "note" %}}
+### Nesting
+
 Nested logic with the same `and`/`or` conjunction can be simplified into a single list.
+
+For example:
+
 ```
 queryPost(filter: {
   or: [

--- a/content/graphql/queries/and-or-not.md
+++ b/content/graphql/queries/and-or-not.md
@@ -91,4 +91,3 @@ queryPost(filter: {
   ]
 } ) { ... }
 ```
-{{% /notice %}}

--- a/content/graphql/queries/and-or-not.md
+++ b/content/graphql/queries/and-or-not.md
@@ -1,5 +1,5 @@
 +++
-title = "And, Or and Not"
+title = "And, Or and Not Operators in GraphQL"
 description = "Every GraphQL search filter can use AND, OR and NOT operators."
 weight = 5
 [menu.main]
@@ -7,17 +7,19 @@ weight = 5
     name = "And, Or and Not"
 +++
 
-Every GraphQL search filter can use `and`, `or` and `not` operators.
+Every GraphQL search filter can use `and`, `or`, and `not` operators.
 
 GraphQL syntax uses infix notation, so: "a and b" is `a, and: { b }`, "a or b or c" is `a, or: { b, or: c }`, and "not" is a prefix (`not:`).
 
-Example: Posts that do not have "GraphQL" in the title.
+The following example queries demonstrate the use of `and`, `or`, and `not` operators:
+
+Example: _"Posts that do not have "GraphQL" in the title"_
 
 ```graphql
 queryPost(filter: { not: { title: { allofterms: "GraphQL"} } } ) { ... }
 ```
 
-Example: Posts that have "GraphQL" or "Dgraph" in the title.
+Example: _"Posts that have "GraphQL" or "Dgraph" in the title"_
 
 ```graphql
 queryPost(filter: {
@@ -26,7 +28,7 @@ queryPost(filter: {
 } ) { ... }
 ```
 
-Example: Posts that have "GraphQL" and "Dgraph" in the title.
+Example: _"Posts that have "GraphQL" and "Dgraph" in the title"_
 
 ```graphql
 queryPost(filter: {
@@ -35,7 +37,7 @@ queryPost(filter: {
 } ) { ... }
 ```
 
-The "and" operator is implicit for a single filter object, if the fields don't overlap.  For example, above the `and` is required because `title` is in both filters, whereas below, `and` is not required.
+The `and` operator is implicit for a single filter object, if the fields don't overlap.  For example, above the `and` is required because `title` is in both filters; whereas below, `and` is not required.
 
 ```graphql
 queryPost(filter: {
@@ -44,7 +46,7 @@ queryPost(filter: {
 } ) { ... }
 ```
 
-Example: Posts that have "GraphQL" in the title, or have the tag "GraphQL" and mention "Dgraph" in the title
+Example: _"Posts that have "GraphQL" in the title, or have the tag "GraphQL" and mention "Dgraph" in the title"_
 
 ```graphql
 queryPost(filter: {
@@ -53,9 +55,9 @@ queryPost(filter: {
 } ) { ... }
 ```
 
-The `and` and `or` filter both accept a list of filters. Per the GraphQL specification, non-list filters are coerced into a list. This provides backwards compatibility while allowing for more complex filters.
+The `and` and `or` filter both accept a list of filters. Per the GraphQL specification, non-list filters are coerced into a list. This provides backwards-compatibility while allowing for more complex filters.
 
-Example: Query for posts that have `GraphQL` in the title but that lack the `GraphQL` tag, or that have `Dgraph` in the title but lack the `Dgraph` tag.
+Example: _"Query for posts that have `GraphQL` in the title but that lack the `GraphQL` tag, or that have `Dgraph` in the title but lack the `Dgraph` tag"_
 
 ```graphql
 queryPost(filter: {
@@ -70,7 +72,7 @@ queryPost(filter: {
 
 Nested logic with the same `and`/`or` conjunction can be simplified into a single list.
 
-For example:
+For example, the following complex query:
 
 ```
 queryPost(filter: {
@@ -80,7 +82,7 @@ queryPost(filter: {
   ]
 } ) { ... }
 ```
-Can be simplified into
+...can be simplified into the following simplified query syntax:
 ```
 queryPost(filter: {
   or: [

--- a/content/graphql/queries/and-or-not.md
+++ b/content/graphql/queries/and-or-not.md
@@ -21,36 +21,36 @@ Example: Posts that have "GraphQL" or "Dgraph" in the title.
 
 ```graphql
 queryPost(filter: {
-    title: { allofterms: "GraphQL"},
-    or: { title: { allofterms: "Dgraph" } }
-  } ) { ... }
+  title: { allofterms: "GraphQL"},
+  or: { title: { allofterms: "Dgraph" } }
+} ) { ... }
 ```
 
 Example: Posts that have "GraphQL" and "Dgraph" in the title.
 
 ```graphql
 queryPost(filter: {
-    title: { allofterms: "GraphQL"},
-    and: { title: { allofterms: "Dgraph" } }
-  } ) { ... }
+  title: { allofterms: "GraphQL"},
+  and: { title: { allofterms: "Dgraph" } }
+} ) { ... }
 ```
 
 The "and" operator is implicit for a single filter object, if the fields don't overlap.  For example, above the `and` is required because `title` is in both filters, whereas below, `and` is not required.
 
 ```graphql
 queryPost(filter: {
-    title: { allofterms: "GraphQL" },
-    datePublished: { ge: "2020-06-15" }
-  } ) { ... }
+  title: { allofterms: "GraphQL" },
+  datePublished: { ge: "2020-06-15" }
+} ) { ... }
 ```
 
 Example: Posts that have "GraphQL" in the title, or have the tag "GraphQL" and mention "Dgraph" in the title
 
 ```graphql
 queryPost(filter: {
-    title: { allofterms: "GraphQL"},
-    or: { title: { allofterms: "Dgraph" }, tags: { eq: "GraphQL" } }
-  } ) { ... }
+  title: { allofterms: "GraphQL"},
+  or: { title: { allofterms: "Dgraph" }, tags: { eq: "GraphQL" } }
+} ) { ... }
 ```
 
 The `and` and `or` filter both accept a list of filters. Per the GraphQL specification, non-list filters are coerced into a list. This provides backwards compatibility while allowing for more complex filters.
@@ -59,9 +59,32 @@ Example: Query for posts that have `GraphQL` in the title but that lack the `Gra
 
 ```graphql
 queryPost(filter: {
-    or: [
-      and: [{ title: { allofterms: "GraphQL" } }, { not: { tags: { eq: "GraphQL" } } }]
-      and: [{ title: { allofterms: "Dgraph" } }, { not: { tags: { eq: "Dgraph" } } }]
-    ]
-  } ) { ... }
+  or: [
+    { and: [{ title: { allofterms: "GraphQL" } }, { not: { tags: { eq: "GraphQL" } } }] }
+    { and: [{ title: { allofterms: "Dgraph" } }, { not: { tags: { eq: "Dgraph" } } }] }
+  ]
+} ) { ... }
 ```
+
+{{% notice "note" %}}
+Nested logic with the same `and`/`or` conjunction can be simplified into a single list.
+```
+queryPost(filter: {
+  or: [
+    { or: [ { foo: { eq: "A" } }, { bar: { eq: "B" } } ] },
+    { or: [ { baz: { eq: "C" } }, { quz: { eq: "D" } } ] }
+  ]
+} ) { ... }
+```
+Can be simplified into
+```
+queryPost(filter: {
+  or: [
+    { foo: { eq: "A" } }, 
+    { bar: { eq: "B" } },
+    { baz: { eq: "C" } }, 
+    { quz: { eq: "D" } }
+  ]
+} ) { ... }
+```
+{{% /notice %}}


### PR DESCRIPTION
fix syntax error, normalize indention, and add notice about combining nested filters


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
