### PR TITLE
Docs(GraphQL): Emphasize that @search annotation is required for filtering on predicates

### DIFF
--- a/content/graphql/queries/search-filtering.md
+++ b/content/graphql/queries/search-filtering.md
@@ -150,7 +150,7 @@ query {
 }
 ```
 
-And events that have a location near a certain point can be filtered like this:
+You can also filter events that have a location near a certain point with the following query:
 
 ```
 query {

--- a/content/graphql/queries/search-filtering.md
+++ b/content/graphql/queries/search-filtering.md
@@ -140,7 +140,7 @@ type Event {
 }
 ```
 
-The search directive would allow filtering events that fall between dates like this:
+The search directive would let you filter events that fall within a date range, as follows:
 
 ```
 query {

--- a/content/graphql/queries/search-filtering.md
+++ b/content/graphql/queries/search-filtering.md
@@ -130,7 +130,7 @@ query {
 
 Before filtering an object by a predicate, you need to add a `@search` directive to the field that will be used to filter the results.
 
-For example, if you wanted to query events between two dates, or events that fall within a certain radius of a point, you could have an Event schema like this:
+For example, if you wanted to query events between two dates, or events that fall within a certain radius of a point, you could have an `Event` schema, as follows:
 
 ```
 type Event {

--- a/content/graphql/queries/search-filtering.md
+++ b/content/graphql/queries/search-filtering.md
@@ -128,7 +128,7 @@ query {
 
 ### Query that filters objects by predicate
 
-Before filtering an object by a predicate, you need to add a @search directive to the field that will be used to filter the results.
+Before filtering an object by a predicate, you need to add a `@search` directive to the field that will be used to filter the results.
 
 For example, if you wanted to query events between two dates, or events that fall within a certain radius of a point, you could have an Event schema like this:
 

--- a/content/graphql/queries/search-filtering.md
+++ b/content/graphql/queries/search-filtering.md
@@ -126,7 +126,46 @@ query {
 }
 ```
 
-You also filter posts by different fields in the `Post` type that have a `@search` directive applied. To only fetch posts which have `GraphQL` in their title and have a `score > 100`, you can run the following query:
+### Query that filters objects by predicate
+
+Before filtering an object by a predicate, you need to add a @search directive to the field that will be used to filter the results.
+
+For example, if you wanted to query events between two dates, or events that fall within a certain radius of a point, you could have an Event schema like this:
+
+```
+type Event {
+  id: ID!
+  date: DateTime! @search
+  location: Point @search
+}
+```
+
+The search directive would allow filtering events that fall between dates like this:
+
+```
+query {
+  queryEvent (filter: { date: { between: { min: "2020-01-01", max: "2020-02-01" } } }) {
+    id
+  }
+}
+```
+
+And events that have a location near a certain point can be filtered like this:
+
+```
+query {
+  queryEvent (filter: { location: { near: { coordinate: { latitude: 37.771935, longitude: -122.469829 }, distance: 1000 } } }) {
+    id
+  }
+}
+```
+
+
+You can also use connectors such as the `and` keyword to show results with multiple filters applied. In the query below, we fetch posts that have `GraphQL` in their title and have a `score > 100`.
+
+This example assumes that the `Post` type has a `@search` directive applied to the `title` field and the `score` field.
+
+
 
 ```graphql
 query {


### PR DESCRIPTION
I missed this requirement when reading this page, so I couldn't understand why I got weird errors like "Field "virtualEventUrl" is not defined by type EventFilter." I understood it after getting help in the forums. https://discuss.dgraph.io/t/how-do-you-create-parameterized-graphql-queries/14711 Hopefully this will prevent others from making the same mistake.


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
