### PR TITLE
docs(cdc): Add flag for SASL mechanism.

### DIFF
--- a/content/enterprise-features/change-data-capture.md
+++ b/content/enterprise-features/change-data-capture.md
@@ -52,15 +52,18 @@ dgraph alpha --cdc "file=local-file-path"
 The `--cdc` option includes several sub-options that you can use to configure
 CDC when running the `dgraph alpha` command:
 
-| Sub-option       | Example `dgraph alpha` command option     | Notes                                                                |
-|------------------|-------------------------------------------|----------------------------------------------------------------------|
-|  `ca-cert`       | `--cdc "ca-cert=/cert-dir/ca.crt"`        | Path and filename of the CA root certificate used for TLS encryption |
-|  `client-cert`   | `--cdc "client-cert=/c-certs/client.crt"` | Path and filename of the client certificate used for TLS encryption  |
-|  `client-key`    | `--cdc "client-cert=/c-certs/client.key"` | Path and filename of the client certificate private key              |
-|  `file`          | `--cdc "file=/sink-dir/cdc-file"`         | Path and filename of a local file sink (alternative to Kafka sink)   |
-|  `kafka`         | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic"` | Hostname(s) of the Kafka hosts. May require authentication using the `sasl-user` and `sasl-password` sub-options. |
-|  `sasl-user`     | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic"` | SASL username for Kafka. Requires the `kafka` and `sasl-password` sub-options. |
-|  `sasl-password` | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic"` | SASL password for Kafka. Requires the `kafka` and `sasl-username` sub-options. |
+| Sub-option       | Example `dgraph alpha` command option                                                                  | Notes                                                                                                             |
+|------------------|--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `ca-cert`        | `--cdc "ca-cert=/cert-dir/ca.crt"`                                                                     | Path and filename of the CA root certificate used for TLS encryption                                              |
+| `client-cert`    | `--cdc "client-cert=/c-certs/client.crt"`                                                              | Path and filename of the client certificate used for TLS encryption                                               |
+| `client-key`     | `--cdc "client-cert=/c-certs/client.key"`                                                              | Path and filename of the client certificate private key                                                           |
+| `file`           | `--cdc "file=/sink-dir/cdc-file"`                                                                      | Path and filename of a local file sink (alternative to Kafka sink)                                                |
+| `kafka`          | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic"`                               | Hostname(s) of the Kafka hosts. May require authentication using the `sasl-user` and `sasl-password` sub-options. |
+| `sasl-user`      | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic"`                               | SASL username for Kafka. Requires the `kafka` and `sasl-password` sub-options.                                    |
+| `sasl-password`  | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic"`                               | SASL password for Kafka. Requires the `kafka` and `sasl-username` sub-options.                                    |
+| `sasl-password`  | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic"`                               | SASL password for Kafka. Requires the `kafka` and `sasl-username` sub-options.                                    |
+| `sasl-mechanism` | `--cdc "kafka=kafka-hostname; sasl-user=tstark; sasl-password=m3Ta11ic; sasl-mechanism=SCRAM-SHA-512"` | The SASL mechanism for Kafka (`PLAIN`, `SCRAM-SHA-256` or `SCRAM-SHA-512`)                                        |
+
 
 ## CDC data format
 


### PR DESCRIPTION
Documents the new option sasl-mechanism under the kafka superflag.

This change was introduced in Dgraph v21.03.1 with PR dgraph-io/dgraph#7765.

Example:

    --kafka="...; sasl-mechanism=SCRAM-SHA-512"


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
