### PR TITLE
Docs(lambda-server): Add correct lambda-url style

### DIFF
--- a/content/graphql/lambda/server.md
+++ b/content/graphql/lambda/server.md
@@ -71,7 +71,7 @@ services:
   dgraph:
     image: dgraph/standalone:latest
     environment: 
-      DGRAPH_ALPHA_GRAPHQL_LAMBDA_URL: "http://dgraph_lambda:8686/graphql-worker"
+      DGRAPH_ALPHA_GRAPHQL: "lambda-url=http://dgraph_lambda:8686/graphql-worker"
     ports:
       - "8080:8080"
       - "9080:9080"


### PR DESCRIPTION
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->

When reading the docs I tried setting the graphql-lambda-server according to the docs.

`DGRAPH_ALPHA_GRAPHQL_LAMBDA_URL: "http://dgraph_lambda:8686/graphql-worker"`

This however did not work and I did some digging discovering that the actual format of this environment variable should be

`DGRAPH_ALPHA_GRAPHQL: "lambda-url=http://dgraph_lambda:8686/graphql-worker"`

So to avoid others also making this mistake I made a PR to update the docs.


link to the forum post: https://discuss.dgraph.io/t/running-dgraph-standalone-along-with-dgraph-dgraph-lambda/14421/6?u=erbo_engineering


