### PR TITLE
Nav(Other): Fixes incorrect docs links

### DIFF
--- a/content/graphql/api/api-overview.md
+++ b/content/graphql/api/api-overview.md
@@ -21,4 +21,4 @@ In each case, both GET and POST requests are served.
 
 - `/admin` is where you'll find an admin API for administering your GraphQL instance. That's where you can update your GraphQL schema, perform health checks of your backend, and more.
 
-This section covers the API served at `/graphql`. See [Admin](/graphql/admin) to learn more about the admin API.
+This section covers the API served at `/graphql`. See [Admin](/docs/graphql/admin) to learn more about the admin API.

--- a/content/graphql/api/multiples.md
+++ b/content/graphql/api/multiples.md
@@ -62,11 +62,11 @@ If a request only has a single query operation, then you can use the short-hand 
 }
 ```
 
-This simplfies queries when a query doesn't require an operation name or [variables](/graphql/api/variables).
+This simplfies queries when a query doesn't require an operation name or [variables](/docs/graphql/api/variables).
 
 ## Multiple Operations
 
-If a request has two or more operations, then each operation must have a name. A request can only execute one operation, so you must also include the operation name to execute in the request (see the "operations" field for [requests](/graphql/api/requests)). Every operation name in a request must be unique.
+If a request has two or more operations, then each operation must have a name. A request can only execute one operation, so you must also include the operation name to execute in the request (see the "operations" field for [requests](/docs/graphql/api/requests)). Every operation name in a request must be unique.
 
 For example, in the following request has the operation names "getTaskAndUser" and "completedTasks".
 

--- a/content/graphql/authorization/directive.md
+++ b/content/graphql/authorization/directive.md
@@ -12,12 +12,12 @@ to define authorization rules for most types (except for `union` and `@remote`
 types). It lets you control which users can run which queries - as well as
 which users can add, update, and delete data using mutations. 
 
-Additionally, you can use this directive with the [`@secret`](/graphql/schema/types#password-type)
+Additionally, you can use this directive with the [`@secret`](/docs/graphql/schema/types#password-type)
 directive; and, if you specify a `password` authorization rule, Dgraph will use
 it to authorize the `check<Type>Password` query.
 
 {{% notice "note" %}}
-The [Union type](/graphql/schema/types#union-type) does not support the `@auth` directive. 
+The [Union type](/docs/graphql/schema/types#union-type) does not support the `@auth` directive. 
 {{% /notice %}}
 
 You create authorization rules using the `@auth` directive, and those rules are
@@ -71,7 +71,7 @@ type Todo @auth(
 {{% notice "note" %}}
 To use the `@auth` directive, you must configure the authentication method used
 by Dgraph in the last line of your schema with a `Dgraph.Authorization` object,
-as described in the [Authorization Overview](/graphql/authorization/authorization-overview).
+as described in the [Authorization Overview](/docs/graphql/authorization/authorization-overview).
 {{% /notice %}}
 
 Here we define a type `Todo`, that has an `id`, the `text` of the todo and the username of the `owner` of the todo.  What todos can a user query?  Any `Todo` that the `query` rule would also return.

--- a/content/graphql/custom/custom-overview.md
+++ b/content/graphql/custom/custom-overview.md
@@ -46,11 +46,11 @@ type MyType {
 
 ## Learn more
 
-Find out more about the  `@custom` directive [here](/graphql/custom/directive), or check out:
+Find out more about the  `@custom` directive [here](/docs/graphql/custom/directive), or check out:
 
-* [custom query examples](/graphql/custom/query)
-* [custom mutation examples](/graphql/custom/mutation), or
-* [custom field examples](/graphql/custom/field)
+* [custom query examples](/docs/graphql/custom/query)
+* [custom mutation examples](/docs/graphql/custom/mutation), or
+* [custom field examples](/docs/graphql/custom/field)
 
 
 

--- a/content/graphql/custom/dql.md
+++ b/content/graphql/custom/dql.md
@@ -15,7 +15,7 @@ DQL lets you build custom logic that goes beyond what is possible with the
 current GraphQL CRUD API.
 
 {{% notice "tip" %}}
-Since v21.03, you can also [subscribe to custom DQL](/graphql/subscriptions/#subscriptions-to-custom-dql) queries.
+Since v21.03, you can also [subscribe to custom DQL](/docs/graphql/subscriptions/#subscriptions-to-custom-dql) queries.
 {{% /notice %}}
 
 For example, lets say you had following schema:
@@ -108,6 +108,6 @@ There are following points to note while specifying the DQL query for such custo
 * For variables, only scalar GraphQL arguments like `Boolean`, `Int`, `Float`, etc are allowed. Lists and Object types are not allowed to be used as variables with DQL queries.
 * You would be able to query only those many levels with GraphQL which you have mapped with the DQL query. For instance, in the first custom query above, we haven't mapped an author's tweets to GraphQL alias, so, we won't be able to fetch author's tweets using that query.
 * If the custom GraphQL query returns an interface, and you want to use `__typename` in GraphQL query, then you should add `dgraph.type` as a field in DQL query without any alias. This is not required for types, only for interfaces.
-* to subscribe to a custom DQL query, use the `@withSubscription` directive. See the [Subscriptions article](/graphql/subscriptions/) for more information.
+* to subscribe to a custom DQL query, use the `@withSubscription` directive. See the [Subscriptions article](/docs/graphql/subscriptions/) for more information.
 
 ---

--- a/content/graphql/custom/mutation.md
+++ b/content/graphql/custom/mutation.md
@@ -45,7 +45,7 @@ type Mutation {
 
 Find out more about how to turn off generated mutations and protecting mutations with authorization rules at:
 
-* [Remote Types - Turning off Generated Mutations with `@remote` Directive](/graphql/custom/directive)
-* [Securing Mutations with the `@auth` Directive](/graphql/authorization/mutations)
+* [Remote Types - Turning off Generated Mutations with `@remote` Directive](/docs/graphql/custom/directive)
+* [Securing Mutations with the `@auth` Directive](/docs/graphql/authorization/mutations)
 
 ---

--- a/content/graphql/directives/index.md
+++ b/content/graphql/directives/index.md
@@ -14,19 +14,19 @@ The list of all directives supported by Dgraph.
 
 `@auth` allows you to define how to apply authorization rules on the queries/mutation for a type.
 
-Reference: [Auth directive](/graphql/authorization/directive)
+Reference: [Auth directive](/docs/graphql/authorization/directive)
 
 ### @cascade
 
 `@cascade` allows you to filter out certain nodes within a query.
 
-Reference: [Cascade](/graphql/queries/cascade)
+Reference: [Cascade](/docs/graphql/queries/cascade)
 
 ### @custom
 
 `@custom` directive is used to define custom queries, mutations and fields.
 
-Reference: [Custom directive](/graphql/custom/directive)
+Reference: [Custom directive](/docs/graphql/custom/directive)
 
 ### @deprecated
 
@@ -44,73 +44,73 @@ Reference: [GraphQL on Existing Dgraph]({{< relref "graphql/dgraph/index.md" >}}
 
 The `@generate` directive is used to specify which GraphQL APIs are generated for a type.
 
-Reference: [Generate directive](/graphql/schema/generate)
+Reference: [Generate directive](/docs/graphql/schema/generate)
 
 ### @hasInverse
 
 `@hasInverse` is used to setup up two way edges such that adding a edge in
 one direction automically adds the one in the inverse direction.
 
-Reference: [Linking nodes in the graph](/graphql/schema/graph-links)
+Reference: [Linking nodes in the graph](/docs/graphql/schema/graph-links)
 
 ### @id
 
 `@id` directive is used to annotate a field which represents a unique identifier coming from outside
  of Dgraph.
 
-Reference: [Identity](/graphql/schema/ids)
+Reference: [Identity](/docs/graphql/schema/ids)
 
 ### @include
 
 The `@include` directive can be used to include a field based on the value of an `if` argument.
 
-Reference: [Include directive](/graphql/queries/skip-include)
+Reference: [Include directive](/docs/graphql/queries/skip-include)
 
 ### @lambda
 
 The `@lambda` directive allows you to call custom JavaScript resolvers. The `@lambda` queries, mutations, and fields are resolved through the lambda functions implemented on a given lambda server.
 
-Reference: [Lambda directive](/graphql/lambda/overview)
+Reference: [Lambda directive](/docs/graphql/lambda/overview)
 
 ### @remote
 
 `@remote` directive is used to annotate types for which data is not stored in Dgraph. These types
 are typically used with custom queries and mutations.
 
-Reference: [Remote directive](/graphql/custom/directive/#remote-types)
+Reference: [Remote directive](/docs/graphql/custom/directive/#remote-types)
 
 ### @remoteResponse
 
 The `@remoteResponse` directive allows you to annotate the fields of a `@remote` type in order to map a custom query's JSON key response to a GraphQL field.
 
-Reference: [Remote directive](/graphql/custom/directive/#remote-response)
+Reference: [Remote directive](/docs/graphql/custom/directive/#remote-response)
 
 ### @search
 
 `@search` allows you to perform filtering on a field while querying for nodes.
 
-Reference: [Search](/graphql/schema/search)
+Reference: [Search](/docs/graphql/schema/search)
 
 ### @secret
 
 `@secret` directive is used to store secret information, it gets encrypted and then stored in Dgraph.
 
-Reference: [Password Type](/graphql/schema/types/#password-type)
+Reference: [Password Type](/docs/graphql/schema/types/#password-type)
 
 ### @skip
 
 The `@skip` directive can be used to fetch a field based on the value of a user-defined GraphQL variable.
 
-Reference: [Skip directive](/graphql/queries/skip-include)
+Reference: [Skip directive](/docs/graphql/queries/skip-include)
 
 ### @withSubscription
 
 `@withSubscription` directive when applied on a type, generates subsciption queries for it.
 
-Reference: [Subscriptions](/graphql/subscriptions)
+Reference: [Subscriptions](/docs/graphql/subscriptions)
 
 ### @lambdaOnMutate
 
 The `@lambdaOnMutate` directive allows you to listen to mutation events(`add`/`update`/`delete`). Depending on the defined events and the occurrence of a mutation event, `@lambdaOnMutate` triggers the appropriate lambda function implemented on a given lambda server.
 
-Reference: [LambdaOnMutate directive](/graphql/lambda/webhook)
+Reference: [LambdaOnMutate directive](/docs/graphql/lambda/webhook)

--- a/content/graphql/lambda/overview.md
+++ b/content/graphql/lambda/overview.md
@@ -19,7 +19,7 @@ This also simplifies the job of developers, as they can build a complex backend 
 Dgraph doesn't execute your custom logic itself. It makes external HTTP requests to a user-defined lambda server. [Dgraph Cloud](https://dgraph.io/cloud) will do all of this for you. 
 
 {{% notice "tip" %}}
-If you want to deploy your own lambda server, you can find the implementation of Dgraph Lambda in our [open-source repository](https://github.com/dgraph-io/dgraph-lambda). Please refer to the documentation on [setting up a lambda server](/graphql/lambda/server) for more details.
+If you want to deploy your own lambda server, you can find the implementation of Dgraph Lambda in our [open-source repository](https://github.com/dgraph-io/dgraph-lambda). Please refer to the documentation on [setting up a lambda server](/docs/graphql/lambda/server) for more details.
 {{% /notice %}}
 
 {{% notice "note" %}}
@@ -298,7 +298,7 @@ query {
 
 To learn more about the `@lambda` directive, see:
 
-* [Lambda fields](/graphql/lambda/field)
-* [Lambda queries](/graphql/lambda/query)
-* [Lambda mutations](/graphql/lambda/mutation)
-* [Lambda server setup](/graphql/lambda/server)
+* [Lambda fields](/docs/graphql/lambda/field)
+* [Lambda queries](/docs/graphql/lambda/query)
+* [Lambda mutations](/docs/graphql/lambda/mutation)
+* [Lambda server setup](/docs/graphql/lambda/server)

--- a/content/graphql/mutations/add.md
+++ b/content/graphql/mutations/add.md
@@ -79,7 +79,7 @@ Variables:
 ```
 
 {{% notice "note" %}}
-You can convert an `add` mutation to an `upsert` mutation by setting the value of the input variable `upsert` to `true`. For more information, see [Upsert Mutations](/graphql/mutations/upsert).
+You can convert an `add` mutation to an `upsert` mutation by setting the value of the input variable `upsert` to `true`. For more information, see [Upsert Mutations](/docs/graphql/mutations/upsert).
 {{% /notice %}}
 
 ## Examples

--- a/content/graphql/overview/index.md
+++ b/content/graphql/overview/index.md
@@ -12,21 +12,21 @@ weight = 1
 
 Designed from the ground up to be run in production, Dgraph is the native GraphQL database with a graph backend. It is open-source, scalable, distributed, highly available and lightning fast.
 
-* These docs tell you all the details.  If you are looking for a walk through tutorial, then head over to our [tutorials section](/graphql/todo-app-tutorial/todo-overview).
+* These docs tell you all the details.  If you are looking for a walk through tutorial, then head over to our [tutorials section](/docs/graphql/todo-app-tutorial/todo-overview).
 
 Dgraph gives you GraphQL.  You're always working with GraphQL, not a translation layer.  When you build an app with Dgraph, Dgraph is your GraphQL database.
 
 ## Exploring the docs
 
-* How it Works - Once you've got yourself started with [tutorials](/graphql/todo-app-tutorial/todo-overview), you might need to review [how it works](/graphql/how-dgraph-graphql-works).
-* [Schema](/graphql/schema/schema-overview) - You'll need the schema reference to find out about all the options of what can be in your schema.
-* [The API](/graphql/api/api-overview) - The API section tells you about how the GraphQL API is served and how you can access it.
-* [Queries](/graphql/queries/queries-overview) - Everything you need to know about writing GraphQL queries.
-* [Mutations](/graphql/mutations/mutations-overview) - Everything you need to know about writing GraphQL mutations with Dgraph.
-* [Subscriptions](/graphql/subscriptions) - GraphQL subscriptions help you make your APP more responsive or, for example, add live feeds.  Dgraph can generate subscriptions for you.
-* [Custom Logic](/graphql/custom/custom-overview) - Dgraph's auto generated GraphQL API is fantastic, but as your app gets more complicated, you'll need to add custom business logic to your API.
-* [Authorization](/graphql/authorization/authorization-overview) - Find out how Dgraph can add automated authorization to your GraphQL API.
-* [Local Administration](/graphql/admin) - Once you're up and running you might also need to know a few details about administering your Dgraph instance if you are running locally.  
+* How it Works - Once you've got yourself started with [tutorials](/docs/graphql/todo-app-tutorial/todo-overview), you might need to review [how it works](/docs/graphql/how-dgraph-graphql-works).
+* [Schema](/docs/graphql/schema/schema-overview) - You'll need the schema reference to find out about all the options of what can be in your schema.
+* [The API](/docs/graphql/api/api-overview) - The API section tells you about how the GraphQL API is served and how you can access it.
+* [Queries](/docs/graphql/queries/queries-overview) - Everything you need to know about writing GraphQL queries.
+* [Mutations](/docs/graphql/mutations/mutations-overview) - Everything you need to know about writing GraphQL mutations with Dgraph.
+* [Subscriptions](/docs/graphql/subscriptions) - GraphQL subscriptions help you make your APP more responsive or, for example, add live feeds.  Dgraph can generate subscriptions for you.
+* [Custom Logic](/docs/graphql/custom/custom-overview) - Dgraph's auto generated GraphQL API is fantastic, but as your app gets more complicated, you'll need to add custom business logic to your API.
+* [Authorization](/docs/graphql/authorization/authorization-overview) - Find out how Dgraph can add automated authorization to your GraphQL API.
+* [Local Administration](/docs/graphql/admin) - Once you're up and running you might also need to know a few details about administering your Dgraph instance if you are running locally.  
 * [Dgraph Cloud](https://dgraph.io/docs/cloud/admin/overview) - If you are using hosted Dgraph on Dgraph Cloud, then head over here to learn about administering your backend.
 
 ## Contribute

--- a/content/graphql/quick-start/index.md
+++ b/content/graphql/quick-start/index.md
@@ -41,7 +41,7 @@ With Dgraph you can turn that schema into a running GraphQL API in just two step
 
 ## Step 1 - Start Dgraph GraphQL
 
-It's a one-liner to bring up Dgraph with GraphQL.  *Note: The Dgraph standalone image is great for quick start and exploring, but it's not meant for production use.  Once you want to build an App or persist your data for restarts, you'll need to review the   [admin docs](/graphql/admin).*
+It's a one-liner to bring up Dgraph with GraphQL.  *Note: The Dgraph standalone image is great for quick start and exploring, but it's not meant for production use.  Once you want to build an App or persist your data for restarts, you'll need to review the   [admin docs](/docs/graphql/admin).*
 
 ```
 docker run -it -p 8080:8080 dgraph/standalone:master

--- a/content/graphql/schema/migration.md
+++ b/content/graphql/schema/migration.md
@@ -41,7 +41,7 @@ situation where you need migration.
 
 This can be handled in a couple of ways:
 1. Migrate all the data for type `User` to use the new name `AppUser`. OR,
-2. Just use the [`@dgraph(type: ...)`](/graphql/dgraph) directive to maintain backward compatibility 
+2. Just use the [`@dgraph(type: ...)`](/docs/graphql/dgraph) directive to maintain backward compatibility 
    with the existing data.
 
 Depending on your use-case, you might find option 1 or 2 better for you. For example, if you 
@@ -82,7 +82,7 @@ and now you figured that it would be better to call `phone` as `tel`. You need m
 
 You have the same two choices as before:
 1. Migrate all the data for the field `phone` to use the new name `tel`. OR,
-2. Just use the [`@dgraph(pred: ...)`](/graphql/dgraph) directive to maintain backward compatibility
+2. Just use the [`@dgraph(pred: ...)`](/docs/graphql/dgraph) directive to maintain backward compatibility
    with the existing data.
    
 Here's an example if you want to go with option #2:

--- a/content/graphql/schema/schema-overview.md
+++ b/content/graphql/schema/schema-overview.md
@@ -13,4 +13,4 @@ The process for serving GraphQL with Dgraph is to add a set of GraphQL type defi
 
 The input schema may contain interfaces, types and enums that follow the usual GraphQL syntax and validation rules. 
 
-If you want to make your schema editing experience nicer, you should use an editor that does syntax highlighting for GraphQL.  With that, you may also want to include the definitions [here](/graphql/schema/dgraph-schema) as an import.
+If you want to make your schema editing experience nicer, you should use an editor that does syntax highlighting for GraphQL.  With that, you may also want to include the definitions [here](/docs/graphql/schema/dgraph-schema) as an import.

--- a/content/graphql/todo-app-tutorial/todo-overview.md
+++ b/content/graphql/todo-app-tutorial/todo-overview.md
@@ -11,11 +11,11 @@ This is a simple tutorial that will take you through making a basic to-do list a
 
 ### Steps
 
-- [Schema Design](/graphql/todo-app-tutorial/todo-schema-design)
-- [Basic UI](/graphql/todo-app-tutorial/todo-ui)
-- [Add Auth Rules](/graphql/todo-app-tutorial/todo-auth-rules)
-- [Use Auth0's JWT](/graphql/todo-app-tutorial/todo-auth0-jwt)
-- [Use Firebase's JWT](/graphql/todo-app-tutorial/todo-firebase-jwt)
-- [Deploy on Dgraph Cloud](/graphql/todo-app-tutorial/deploy)
+- [Schema Design](/docs/graphql/todo-app-tutorial/todo-schema-design)
+- [Basic UI](/docs/graphql/todo-app-tutorial/todo-ui)
+- [Add Auth Rules](/docs/graphql/todo-app-tutorial/todo-auth-rules)
+- [Use Auth0's JWT](/docs/graphql/todo-app-tutorial/todo-auth0-jwt)
+- [Use Firebase's JWT](/docs/graphql/todo-app-tutorial/todo-firebase-jwt)
+- [Deploy on Dgraph Cloud](/docs/graphql/todo-app-tutorial/deploy)
 
 ---


### PR DESCRIPTION
A number of links in the dgraph docs are broken. They are missing the `/docs/` url prefix which causes them to 404. This PR fixes these links.