### PR TITLE
Docs(ACL and Multi-Tenancy): Modify pages to include info about managing access for all predicates

### DIFF
--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -534,6 +534,37 @@ mutation {
 }
 ```
 
+### Assign permissions over all predicates in a namespace
+
+When you have the [Multi-tenancy](https://dgraph.io/docs/enterprise-features/multitenancy/) feature enabled for your backend, you could have different predicates created for different tenants. There could be a need to assign the same set of permissions to a group over all the predicates of a specific namespace.
+Also, assigning permissions to new predicates as they get created could turn out to be a tedious process for a backend with multi-tenancy enabled.
+
+Dgraph allows for providing a group, access to all the predicates in a particular namespace using a keyword `dgraph.all`. The following example provides to `dev` group, `read+write` access to all the predicates using the `dgraph.all` keyword:
+
+```graphql
+mutation {
+  updateGroup(
+    input: {
+      filter: { name: { eq: "dev" } }
+      set: { rules: [{ predicate: "dgraph.all", permission: 6 }] }
+    }
+  ) {
+    group {
+      name
+      rules {
+        permission
+        predicate
+      }
+    }
+  }
+}
+```
+
+{{% notice "note" %}}
+The permission assigned to a group e.g. `dev` is a union of permissions from `dgraph.all` and the permissions over a specific predicate e.g. `name`. So if `dgraph.all` is assigned the `READ` permission and predicate `name` is assigned the `WRITE` permission the group will have both `READ` and `WRITE` permissions as a result of that union. 
+{{% /notice %}}
+
+
 ### Remove a rule from a group
 
 To remove a rule or rules from the group `dev`, the mutation should be:

--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -534,12 +534,10 @@ mutation {
 }
 ```
 
-### Assign permissions over all predicates in a namespace
 
-When you have the [Multi-tenancy](https://dgraph.io/docs/enterprise-features/multitenancy/) feature enabled for your backend, you could have different predicates created for different tenants. There could be a need to assign the same set of permissions to a group over all the predicates of a specific namespace.
-Also, assigning permissions to new predicates as they get created could turn out to be a tedious process for a backend with multi-tenancy enabled.
+In some cases, it may be desirable to manage permissions for all the predicates together rather than individual ones. This can be achieved using the `dgraph.all` keyword.
 
-Dgraph allows for providing a group, access to all the predicates in a particular namespace using a keyword `dgraph.all`. The following example provides to `dev` group, `read+write` access to all the predicates using the `dgraph.all` keyword:
+The following example provides `read+write` access to the `dev` group over all the predicates of a given namespace using the `dgraph.all` keyword.
 
 ```graphql
 mutation {
@@ -561,7 +559,7 @@ mutation {
 ```
 
 {{% notice "note" %}}
-The permission assigned to a group e.g. `dev` is a union of permissions from `dgraph.all` and the permissions over a specific predicate e.g. `name`. So if `dgraph.all` is assigned the `READ` permission and predicate `name` is assigned the `WRITE` permission the group will have both `READ` and `WRITE` permissions as a result of that union. 
+The permissions assigned to a group `dev` is the union of permissions from `dgraph.all` and permissions for a specific predicate `name`. So if the group is assigned `READ` permission for `dgraph.all` and `WRITE` permission for predicate `name` it will have both, `READ` and `WRITE` permissions for the `name` predicate, as a result of the union. 
 {{% /notice %}}
 
 

--- a/content/enterprise-features/multitenancy.md
+++ b/content/enterprise-features/multitenancy.md
@@ -46,10 +46,9 @@ The super admin is used only for database administration operations, such as exp
 
 - What's the ACL granularity in a multi-tenancy environment? Is it per tenant?
 
-    The access controls are applied per tenant at a predicate level.
-    For example, the user `John Smith` belonging to the group `Data Approvers` may only have read-only access to predicates,
-    while user `Jane Doe`, who belongs to the group `Data Editors`, can be given access to modify predicates.
-    All of these ACL constraints have to be configured for each tenant. 
+    The access controls are applied per tenant to either specific predicates or all predicates that exist for the tenant.
+    For example, the user `John Smith` belonging to the group `Data Approvers` for a tenant `Accounting` may only have read-only access over predicates while user `Jane Doe`, belonging to the group `Data Editors` within that same tenant, may have access to modify those predicates.
+    All the ACL rules need to be defined for each tenant in your backend. The level of granularity available allows for defining rules over specific predicates or all predicates belonging to that tenant.
 
 - Are tenants a physical separation or a logical one?
 


### PR DESCRIPTION
Modified pages for Access Control Lists and Multi-Tenancy outlining the process to define access rules over all predicates that exist in a particular namespace. 
The changes pertain to the new feature introduced as per [this Dgraph PR](https://github.com/dgraph-io/dgraph/pull/7991)

