### PR TITLE
chore: Update build script for latest release.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,7 +33,7 @@ THEME_BRANCH="${THEME_BRANCH:-master}"
 
 getMajorVersions=$(curl -s https://get.dgraph.io/latest \
 | grep -o '"majorReleases":.*]' | grep -o '".*"' |  grep -o '"[^[]*$' \
-| sed  "s/\"//g"  | sed  "s/\,/ /g" | sed  "s/v20.03/ /g")
+| sed  "s/\"//g"  | sed  "s/\,/ /g" | sed  "s/v20.03/ /g" | sed "s/v20.07/ /g")
 
 MAJOR_VERSIONS=(
   $getMajorVersions


### PR DESCRIPTION
Along with https://github.com/dgraph-io/hugo-docs/pull/109, update the build script to build docs for the Dgraph v21.12 Zion release.

* Ignore v20.07 docs


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
