### PR TITLE
Docs(Other): Fix environment variable name for setting lambda URL

### DIFF
--- a/content/graphql/lambda/server.md
+++ b/content/graphql/lambda/server.md
@@ -71,7 +71,7 @@ services:
   dgraph:
     image: dgraph/standalone:latest
     environment: 
-      DGRAPH_ALPHA_GRAPHQL: "lambda-url=http://dgraph_lambda:8686/graphql-worker"
+      DGRAPH_ALPHA_LAMBDA: "url=http://dgraph_lambda:8686/graphql-worker"
     ports:
       - "8080:8080"
       - "9080:9080"


### PR DESCRIPTION
**Description**

Current docker-compose.yml snippet has incorrect env variable. As a result, the lambda server URL is ignored. The new syntax was introduced in: https://github.com/dgraph-io/dgraph/commit/12c3ef564cde11ecc3de96ec1516b3148e52d795

This PR fixes this issue.
