### PR TITLE
Docs(Dgraph): Update migrate tool config file format

### DIFF
--- a/content/migration/migrate-tool.md
+++ b/content/migration/migrate-tool.md
@@ -52,25 +52,25 @@ and hence, the predicate `posts.Body` is of type `string`: `posts.Body: string .
 
 ### Using the Migration tool
 
-Create a `config.properties` file that has the following settings (values should not be in quotes):
+Create a `config.yml` file that has the following settings (values should not be in quotes):
 
 ```txt
-user = <the username for logging in to the SQL database>
-password = <the password for logging in to the SQL database>
-db = <the SQL database to be migrated>
+user: <the username for logging in to the SQL database>
+password: <the password for logging in to the SQL database>
+db: <the SQL database to be migrated>
 ```
 
 For example:
 
-```txt
-user = lucas
-password = MySecretPassword123
-db = stackoverflow
+```yml
+user: lucas
+password: MySecretPassword123
+db: stackoverflow
 ```
 
 Next, export the SQL database into a schema and RDF file, e.g. the `schema.txt` and `sql.rdf` file below:
 ```sh
-dgraph migrate --config config.properties --output_schema schema.txt --output_data sql.rdf
+dgraph migrate --config config.yml --output_schema schema.txt --output_data sql.rdf
 ```
 
 You should get an output such as:


### PR DESCRIPTION
The properties file format is not accepted anymore (at least not by v21.12.0).

<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from master to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `master` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `master` branch when you can, so that we only cherry-pick out of `master`, not into `master`.
-->
