### PR TITLE
Docs(Enterprise): Notify that offline restore feature is deprecated

### DIFF
--- a/content/enterprise-features/binary-backups.md
+++ b/content/enterprise-features/binary-backups.md
@@ -614,7 +614,7 @@ input RestoreInput {
 Restore requests will return immediately without waiting for the operation to
 finish.
 
-## Offline restore
+## Offline restore (DEPRECATED)
 
 The restore utility is now a standalone tool. A new flag, `--encryption key-file=value`, is now part of the restore utility, so you can use it to decrypt the backup. The file specified using this flag must contain the same key that was used for encryption during backup. Alternatively, starting with `v20.07.0`, the `vault` superflag can be used to restore a backup.
 


### PR DESCRIPTION
Description:

The offline restore feature is deprecated (v21.03.0 was the last version to have it), but it is not stated in the docs, which might confuse readers. So, I think we should do something to notify of this change.