### PR TITLE
Docs(Go Clients): install dgo/v210 instead of dgo/v200.

### DIFF
--- a/content/clients/go.md
+++ b/content/clients/go.md
@@ -15,7 +15,7 @@ The client can be obtained in the usual way via `go get`:
 ```sh
  Requires at least Go 1.11
 export GO111MODULE=on
-go get -u -v github.com/dgraph-io/dgo/v200
+go get -u -v github.com/dgraph-io/dgo/v210
 ```
 
 The full [GoDoc](https://godoc.org/github.com/dgraph-io/dgo) contains


### PR DESCRIPTION
Reference https://github.com/dgraph-io/dgraph-docs/pull/284

dgo.DialCloud() is available since dgo/v210

>This release works for dgraph versions >= 21.03. This version adheres to the contract of multi-tenancy.