### PR TITLE
docs(Ratel): Update Ratel information across all docs.

### DIFF
--- a/content/deploy/download.md
+++ b/content/deploy/download.md
@@ -84,7 +84,7 @@ dgraph
 You can build the Ratel UI from source separately following its build
 [instructions](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md).
 Ratel UI is distributed via Dgraph releases using any of the download methods
-listed above.
+listed above. You can also use http://play.dgraph.io/ to run Ratel.
 {{% /notice %}}
 
 Make sure you have [Go](https://golang.org/dl/) v1.11+ installed.

--- a/content/deploy/download.md
+++ b/content/deploy/download.md
@@ -84,7 +84,7 @@ dgraph
 You can build the Ratel UI from source separately following its build
 [instructions](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md).
 Ratel UI is distributed via Dgraph releases using any of the download methods
-listed above. You can also use http://play.dgraph.io/ to run Ratel.
+listed above. You can also use https://play.dgraph.io/ to run Ratel.
 {{% /notice %}}
 
 Make sure you have [Go](https://golang.org/dl/) v1.11+ installed.

--- a/content/deploy/multi-host-setup.md
+++ b/content/deploy/multi-host-setup.md
@@ -190,7 +190,7 @@ Output:
 
 ```
 ID                NAME               MODE            REPLICAS      IMAGE                     PORTS
-vp5bpwzwawoe      dgraph_ratel       replicated      1/1           dgraph/dgraph:latest      *:8000->8000/tcp
+vp5bpwzwawoe      dgraph_ratel       replicated      1/1           dgraph/ratel:latest      *:8000->8000/tcp
 69oge03y0koz      dgraph_alpha2      replicated      1/1           dgraph/dgraph:latest      *:8081->8081/tcp,*:9081->9081/tcp
 kq5yks92mnk6      dgraph_alpha3      replicated      1/1           dgraph/dgraph:latest      *:8082->8082/tcp,*:9082->9082/tcp
 uild5cqp44dz      dgraph_zero        replicated      1/1           dgraph/dgraph:latest      *:5080->5080/tcp,*:6080->6080/tcp
@@ -247,7 +247,7 @@ i3iq5mwhxy8a      dgraph_alpha2      replicated      1/1           dgraph/dgraph
 wgn5adzk67n4      dgraph_alpha4      replicated      1/1           dgraph/dgraph:latest      *:8083->8083/tcp, *:9083->9083/tcp
 uzviqxv9fp2a      dgraph_alpha5      replicated      1/1           dgraph/dgraph:latest      *:8084->8084/tcp, *:9084->9084/tcp
 nl1j457ko54g      dgraph_alpha6      replicated      1/1           dgraph/dgraph:latest      *:8085->8085/tcp, *:9085->9085/tcp
-s11bwr4a6371      dgraph_ratel       replicated      1/1           dgraph/dgraph:latest      *:8000->8000/tcp
+s11bwr4a6371      dgraph_ratel       replicated      1/1           dgraph/ratel:latest      *:8000->8000/tcp
 vchibvpquaes      dgraph_zero1       replicated      1/1           dgraph/dgraph:latest      *:5080->5080/tcp, *:6080->6080/tcp
 199rezd7pw7c      dgraph_zero2       replicated      1/1           dgraph/dgraph:latest      *:5081->5081/tcp, *:6081->6081/tcp
 yb8ella56oxt      dgraph_zero3       replicated      1/1           dgraph/dgraph:latest      *:5082->5082/tcp, *:6082->6082/tcp

--- a/content/deploy/single-host-setup.md
+++ b/content/deploy/single-host-setup.md
@@ -39,9 +39,11 @@ To learn more about other flags, run the following command:
 
 ### Run Dgraph's Ratel UI
 
-```sh
-dgraph-ratel
-```
+Ratel's binary now has its own Docker image https://hub.docker.com/r/dgraph/ratel/tags?page=1&ordering=last_updated - You can also use https://play.dgraph.io/ instead of the image.
+
+{{% notice "note" %}}
+Pay attention that this is an HTTPS site. Google has removed communication between non-HTTPS applications. That is, a local Dgraph will hardly connect to a Ratel using TLS/SSL. In case of a local cluster without HTTPS, use the docker image locally as well.
+{{% /notice %}}
 
 ## Run using Docker
 

--- a/content/deploy/single-host-setup.md
+++ b/content/deploy/single-host-setup.md
@@ -39,7 +39,10 @@ To learn more about other flags, run the following command:
 
 ### Run Dgraph's Ratel UI
 
-Ratel's binary now has its own Docker image https://hub.docker.com/r/dgraph/ratel/tags?page=1&ordering=last_updated - You can also use https://play.dgraph.io/ instead of the image.
+Ratel provides data visualization and cluster management for Dgraph. To get started with Ratel, use it online with the [Dgraph Ratel Dashboard](https://play.dgraph.io) or clone and build Ratel using the [instructions
+from the Ratel repository on GitHub](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md). To learn more, see [Ratel Overview]({{< relref "/ratel/overview" >}}).
+
+Ratel's binary now has its own Docker image https://hub.docker.com/r/dgraph/ratel/tags?page=1&ordering=last_updated
 
 {{% notice "note" %}}
 Pay attention that this is an HTTPS site. Google has removed communication between non-HTTPS applications. That is, a local Dgraph will hardly connect to a Ratel using TLS/SSL. In case of a local cluster without HTTPS, use the docker image locally as well.
@@ -86,11 +89,6 @@ mkdir ~/server2 # Or any other directory where data should be stored.
 docker run -it -p 7081:7081 --network dgraph_default -p 8081:8081 -p 9081:9081 -v ~/server2:/dgraph dgraph/dgraph:{{< version >}} dgraph alpha --zero=HOSTIPADDR:5080 --my=HOSTIPADDR:7081  -o=1
 ```
 Notice the use of -o for server2 to override the default ports for server2.
-
-### Run Dgraph's Ratel UI
-
-Ratel provides data visualization and cluster management for Dgraph. To get started with Ratel, use it online with the [Dgraph Ratel Dashboard](https://play.dgraph.io) or clone and build Ratel using the [instructions
-from the Ratel repository on GitHub](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md). To learn more, see [Ratel Overview]({{< relref "/ratel/overview" >}}).
 
 ## Run using Docker Compose (On single AWS instance)
 

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -115,7 +115,7 @@ in the command shown above to the version number for a previous release, such as
 {{% /notice %}}
 
 After following these steps, Dgraph Alpha now runs and listens for HTTP requests
-on port 8080, and Ratel listens on port 8000(you can also use http://play.dgraph.io/ to run Ratel).
+on port 8080, and Ratel listens on port 8000(you can also use https://play.dgraph.io/ to run Ratel).
 
 ## Dgraph and GraphQL
 

--- a/content/dgraph-overview.md
+++ b/content/dgraph-overview.md
@@ -106,7 +106,7 @@ Docker image to try out Dgraph on Windows or macOS.
 4. Run the Dgraph Docker standalone image, as follows:
 
 ```sh
-  docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph --name dgraph dgraph/standalone:v21.03.0
+  docker run -it -p 5080:5080 -p 6080:6080 -p 8080:8080 -p 9080:9080 -v ~/dgraph:/dgraph --name dgraph dgraph/standalone:{{< version >}}
 ```  
 
 {{% notice "tip" %}}
@@ -115,7 +115,7 @@ in the command shown above to the version number for a previous release, such as
 {{% /notice %}}
 
 After following these steps, Dgraph Alpha now runs and listens for HTTP requests
-on port 8080, and Ratel listens on port 8000.
+on port 8080, and Ratel listens on port 8000(you can also use http://play.dgraph.io/ to run Ratel).
 
 ## Dgraph and GraphQL
 

--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -68,7 +68,7 @@ You would find the Dgraph data stored in a folder named *dgraph* of your *home d
 
 {{% notice "tip" %}}
 Once Dgraph is running, you can access **Ratel** at
-http://play.dgraph.io. It allows browser-based
+https://play.dgraph.io. It allows browser-based
 queries, mutations and visualizations. You can connect Ratel with your Dgraph
 cluster by putting in your Dgraph Alpha address (`http://localhost:8080`) inside the
 **Dgraph Server URL** box in Ratel. To learn more, see the docs on Ratel's [Connection]({{< relref "ratel/connection.md"

--- a/content/get-started/index.md
+++ b/content/get-started/index.md
@@ -18,7 +18,7 @@ You can find the getting started tutorial series [here]({{< relref "tutorials/in
 Designed from the ground up to be run in production, **Dgraph** is the native GraphQL database with a graph backend. It is open-source, scalable, distributed, highly available and lightning fast.
 
 
-Dgraph cluster consists of different nodes (Zero, Alpha & Ratel), and each node serves a
+Dgraph cluster consists of different nodes (Zero, Alpha), and each node serves a
 different purpose.
 
 - **Dgraph Zero** controls the Dgraph cluster, assigns servers to a group,
@@ -55,25 +55,28 @@ Follow the instructions [here](https://docs.docker.com/install) to install
 Docker if you don't have it already.
 
 ```sh
-docker run --rm -it -p "8080:8080" -p "9080:9080" -p "8000:8000" -v ~/dgraph:/dgraph "dgraph/standalone:{{< version >}}"
+docker run --rm -it -p "8080:8080" -p "9080:9080" -v ~/dgraph:/dgraph "dgraph/standalone:{{< version >}}"
 ```
 {{% notice "note" %}}This standalone image is meant for quickstart purposes only.
 It is not recommended for production environments.
 {{% /notice %}}
 
-This would start a single container with **Dgraph Alpha**, **Dgraph Zero** and **Ratel** running in it.
+This would start a single container with **Dgraph Alpha** and **Dgraph Zero** running in it.
 You would find the Dgraph data stored in a folder named *dgraph* of your *home directory*.
 
 ### Step 2: Run Mutation
 
 {{% notice "tip" %}}
-Once Dgraph is running, you can access **Ratel** at [`http://localhost:8000`](http://localhost:8000).
-It allows browser-based queries, mutations and visualizations.
+Once Dgraph is running, you can access **Ratel** at
+http://play.dgraph.io. It allows browser-based
+queries, mutations and visualizations. You can connect Ratel with your Dgraph
+cluster by putting in your Dgraph Alpha address (`http://localhost:8080`) inside the
+**Dgraph Server URL** box in Ratel. To learn more, see the docs on Ratel's [Connection]({{< relref "ratel/connection.md"
+>}}). 
 
 You can run the mutations and queries below from either curl in the command line
 or by pasting the mutation data in **Ratel**.
 {{% /notice %}}
-
 #### Dataset
 The dataset is a movie graph, where the graph nodes are
 entities of the type directors, actors, genres, or movies.

--- a/content/tutorial-1/index.md
+++ b/content/tutorial-1/index.md
@@ -35,7 +35,7 @@ Ensure that [Docker](https://docs.docker.com/install/) is installed and running 
 Now, it's just a matter of running the following command, and you have Dgraph up and running.
 
 ```sh
-docker run --rm -it -p 8000:8000 -p 8080:8080 -p 9080:9080 dgraph/standalone:{{< version >}}
+docker run --rm -it -p 8080:8080 -p 9080:9080 dgraph/standalone:{{< version >}}
 ```
 
 ### Nodes and Edges


### PR DESCRIPTION
ref: https://github.com/dgraph-io/dgraph-docs/pull/249
ref: https://github.com/dgraph-io/dgraph-docs/pull/262

>Remove the ratel command due to deprecation of its binary in the main build.

>We no longer include Ratel in Dgraph Docker images. This PR addresses that with updated information on how to use Ratel in the [Get Started](https://dgraph.io/docs/get-started/) guide.

Fix #300