### PR TITLE
[Docs] Encryption at Rest: added a note for macOS

### DIFF
--- a/content/enterprise-features/encryption-at-rest.md
+++ b/content/enterprise-features/encryption-at-rest.md
@@ -37,7 +37,9 @@ desired key size):
 ```bash
 tr -dc 'a-zA-Z0-9' < /dev/urandom | dd bs=1 count=32 of=enc_key_file
 ```
-
+{{% notice "note" %}}
+On a macOS you may have to use `LC_CTYPE=C; tr -dc 'a-zA-Z0-9' < /dev/urandom | dd bs=1 count=32 of=enc_key_file`. To view the key use `cat enc_key_file`. 
+{{% /notice %}}
 Alternatively, you can use the `--vault` [superflag's]({{< relref "deploy/cli-command-reference.md" >}}) options to enable encryption, as [explained below](#example-using-dgraph-cli-with-hashicorp-vault-configuration).
 
 ## Turn on Encryption
@@ -71,7 +73,7 @@ To use [Hashicorp Vault](https://www.vaultproject.io/), meet the following prere
        "cas": 0
      },
      "data": {
-       "enc_key": "1234567890123456"
+       "enc_key": "qIvHQBVUpzsOp74PmMJjHAOfwIA1e6zm%"
      }
    }
    ```   


### PR DESCRIPTION
- added a note about the command for macOS and the command to view the key.
- updated the key in the example
Fixes: https://github.com/dgraph-io/dgraph-docs/issues/304
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from main to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `main` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `main` branch when you can, so that we only cherry-pick out of `main`, not into `main`.
-->
