### PR TITLE
docs(release): Dgraph v22.0.0 release

### DIFF
--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -6,7 +6,7 @@ title = "Dgraph Releases"
   weight = 14
 +++
 
-The latest Dgraph release is the v21.03 series.
+The latest Dgraph release is the v22.00 series.
 
 Dgraph releases starting with v20.03 follow
 [calendar versioning](https://calver.org). To learn more about our switch from
@@ -23,15 +23,17 @@ To learn about the latest releases and other important announcements, watch the
 
  Dgraph Release Series | Current Release | Supported? | First Release Date | End of life
 -----------------------|-----------------|------------|--------------------|--------------
- v21.03.x              | [v21.03.0][]    | Yes        | March 2021         | March 2022
- v20.11.x              | [v20.11.0][]    | Yes        | December 2020      | December 2021
- v20.07.x              | [v20.07.3][]    | Yes        | July 2020          | July 2021
+ v22.0.x               | [v22.0.0][]     | Yes        | October 2022       | October 2023
+ v21.12.x              | [v21.12.0][]    | No         | December 2021      | December 2022 (discontinued)
+ v21.03.x              | [v21.03.0][]    | No         | March 2021         | March 2022
+ v20.11.x              | [v20.11.0][]    | No         | December 2020      | December 2021
+ v20.07.x              | [v20.07.3][]    | No         | July 2020          | July 2021
  v20.03.x              | [v20.03.7][]    | No         | March 2020         | March 2021
  v1.2.x                | [v1.2.8][]      | No         | January 2020       | January 2021
  v1.1.x                | [v1.1.1][]      | No         | January 2020       | January 2021
  v1.0.x                | [v1.0.18][]     | No         | December 2017      | March 2020
 
-
+[v22.0.0]: https://discuss.dgraph.io/t/dgraph-v22-0-0-is-now-ga/17889
 [v21.03.0]: https://discuss.dgraph.io/t/release-notes-v21-03-0-resilient-rocket/13587
 [v20.11.0]: https://discuss.dgraph.io/t/release-notes-v20-11-0-tenacious-tchalla/11942
 [v20.07.3]: https://discuss.dgraph.io/t/dgraph-v20-07-3-release/12107

--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -8,11 +8,8 @@ title = "Dgraph Releases"
 
 The latest Dgraph release is the v22.00 series.
 
-Dgraph releases starting with v20.03 follow
-[calendar versioning](https://calver.org). To learn more about our switch from
-semantic to calendar versioning, and why v2-v19 don't exist as a result of this
-switch, see our Blog post on the 
-[switch to calendar versioning](https://dgraph.io/blog/post/dgraph-calendar-versioning/).
+Dgraph releases starting v22.0.0 is following semver
+[See the post here](https://discuss.dgraph.io/t/dgraph-v22-0-0-rc1-20221003-release-candidate/).
 
 To learn about the latest releases and other important announcements, watch the
 [Announce][] category on Discuss.
@@ -23,9 +20,9 @@ To learn about the latest releases and other important announcements, watch the
 
  Dgraph Release Series | Current Release | Supported? | First Release Date | End of life
 -----------------------|-----------------|------------|--------------------|--------------
- v22.0.x               | [v22.0.0][]     | Yes        | October 2022       | October 2023
- v21.12.x              | [v21.12.0][]    | No         | December 2021      | December 2022 (discontinued)
- v21.03.x              | [v21.03.0][]    | No         | March 2021         | March 2022
+ v22.0.x               | [v22.0.0][]     | Yes        | October 2022       | N/A
+ v21.12.x(discontinued)| [v21.12.0][]    | No         | December 2021      | December 2022
+ v21.03.x              | [v21.03.0][]    | Yes        | March 2021         | June 2023
  v20.11.x              | [v20.11.0][]    | No         | December 2020      | December 2021
  v20.07.x              | [v20.07.3][]    | No         | July 2020          | July 2021
  v20.03.x              | [v20.03.7][]    | No         | March 2020         | March 2021


### PR DESCRIPTION
- Update the Releases page with the latest release, Dgraph v22.0.0
- Update the previous versions' patch release information.
- Remove support for  v21.12.x,  v21.03.x, v20.07 and v20.11.
- Set v21.12.x as discontinued
