### PR TITLE
Chore(scripts): Remove duplicate version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,7 +40,6 @@ MAJOR_VERSIONS=(
 )
 
 VERSIONS_ARRAY=(
-  'v22.0'
   ${MAJOR_VERSIONS:0}
   ${MAJOR_VERSIONS[@]:1}
   'main'


### PR DESCRIPTION
As version 22.0.x was released. There's no need to keep it written. It's generating duplicates.