### PR TITLE
Docs(deploy): Clarify options needed for more than 1.1TB per instance

### DIFF
--- a/content/deploy/production-checklist.md
+++ b/content/deploy/production-checklist.md
@@ -55,12 +55,13 @@ Regarding disk IOPS, we recommend:
 * 1000 IOPS minimum
 * 3000 IOPS for medium and large datasets
 
-Instances such as c5d.4xlarge have locally-attached NVMe SSDs with high IOPS. You can also use EBS volumes with provisioned IOPS (io1). If you are not running performance-critical workloads, you can also choose to use cheaper gp2 EBS volumes. AWS introduced the new [gp3](https://aws.amazon.com/about-aws/whats-new/2020/12/introducing-new-amazon-ebs-general-purpose-volumes-gp3/?nc1=h_ls) disks that gives 3000 IOPS at any disk size.
+Instances such as c5d.4xlarge have locally-attached NVMe SSDs with high IOPS. You can also use EBS volumes with provisioned IOPS (io1). If you are not running performance-critical workloads, you can also choose to use cheaper gp2 EBS volumes. Typically, AWS [gp3](https://aws.amazon.com/about-aws/whats-new/2020/12/introducing-new-amazon-ebs-general-purpose-volumes-gp3/?nc1=h_ls) disks are a good option and have 3000 Baseline IOPS at any disk size.
 
 Recommended disk sizes for Dgraph Zero and Dgraph Alpha:
 
 * Dgraph Zero: 200 GB to 300 GB. Dgraph Zero stores cluster metadata information and maintains a write-ahead log for cluster operations.
 * Dgraph Alpha: 250 GB to 750 GB. Dgraph Alpha stores database data, including the schema, indices, and the data values. It maintains a write-ahead log of changes to the database. Your cloud provider may provide better disk performance based on the volume size.
+* If you plan to store over 1.1TB per Dgraph Alpah instance, you must increase either the MaxLevels or TableSizeMultiplier. 
 
 Additional recommendations:
 


### PR DESCRIPTION
A couple times people have added 1.1TB of data to a single Dgraph Alpha and recieved "base level can't be zero" as a slightly cryptic error. This is by design since the default level config only allows 1.1TB in the seven levels initially configured. This change adds minimal language to clarify the situation, so people can at least know the limit and which parameters to alter.

See issue here https://discuss.dgraph.io/t/panic-base-level-cant-be-zero/15715/6 