### PR TITLE
Docs(Other): fix typo error of the filter argument "hotel" to "Hotel"

### DIFF
--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -20,8 +20,12 @@ is only allowed to access the data permitted by the ACL rules.
 
 The ACL feature can be turned on by following these steps:
 
-1. Create a plain text file, and store a randomly generated secret key in it. The secret
+1. Create a plain text file named `hmac_secret_file`, and store a randomly generated secret key in it. The secret
 key is used by Dgraph Alpha nodes to sign JSON Web Tokens (JWT).  Keep this secret key secret to avoid data security issues.  The secret key must have at least 256-bits (32 ASCII characters) to support the HMAC-SHA256 signing algorithm.
+
+   ```bash
+    echo '9z$C&F)J@NcRfUjXn2r5u8x!A%D*G-Ka' > hmac_secret_file
+   ```
 
 2. Start all the Dgraph Alpha nodes in your cluster with the option `--acl secret-file="/path/to/secret"`, and
 make sure that they are all using the same secret key file created in Step 1.  Alternatively, you can [store the secret in Hashicorp Vault](#storing-acl-secret-in-hashicorp-vault).
@@ -41,7 +45,7 @@ Here is an example that starts a Dgraph Zero node and a Dgraph Alpha node with t
 
 ```bash
 ## Create ACL secret key file with 32 ASCII characters
-echo '12345678901234567890123456789012' > hmac_secret_file
+echo '9z$C&F)J@NcRfUjXn2r5u8x!A%D*G-Ka' > hmac_secret_file
 
 ## Start Dgraph Zero in different terminal tab or window
 dgraph zero --my=localhost:5080 --replicas 1 --raft idx=1
@@ -80,7 +84,7 @@ You can run this with:
 
 ```bash
 ## Create ACL secret key file with 32 ASCII characters
-echo '12345678901234567890123456789012' > hmac_secret_file
+echo '9z$C&F)J@NcRfUjXn2r5u8x!A%D*G-Ka' > hmac_secret_file
 
 ## Start Docker Compose
 docker-compose up
@@ -94,7 +98,7 @@ The first step is to encode the secret with base64:
 
 ```bash
 ## encode a secret without newline character and copy to the clipboard
-printf '12345678901234567890123456789012' | base64
+printf '9z$C&F)J@NcRfUjXn2r5u8x!A%D*G-Ka' | base64
 ```
 
 The next step is that we need to create a [Helm](https://helm.sh/) chart config values file, e.g. `dgraph_values.yaml`.  We want to copy the results of encoded secret as paste this into the `hmac_secret_file` like the example below:
@@ -105,7 +109,7 @@ alpha:
   acl:
     enabled: true
     file:
-      hmac_secret_file: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+      hmac_secret_file: 9z$C&F)J@NcRfUjXn2r5u8x!A%D*G-Ka
   configFile:
     config.yaml: |
       acl:
@@ -138,7 +142,7 @@ Do the following to set up on the [Hashicorp Vault](https://www.vaultproject.io/
        "cas": 0
      },
      "data": {
-       "hmac_secret_file": "12345678901234567890123456789012"
+       "hmac_secret_file": "9z$C&F)J@NcRfUjXn2r5u8x!A%D*G-Ka"
      }
    }
    ```   

--- a/content/enterprise-features/encryption-at-rest.md
+++ b/content/enterprise-features/encryption-at-rest.md
@@ -37,7 +37,9 @@ desired key size):
 ```bash
 tr -dc 'a-zA-Z0-9' < /dev/urandom | dd bs=1 count=32 of=enc_key_file
 ```
-
+{{% notice "note" %}}
+On a macOS you may have to use `LC_CTYPE=C; tr -dc 'a-zA-Z0-9' < /dev/urandom | dd bs=1 count=32 of=enc_key_file`. To view the key use `cat enc_key_file`. 
+{{% /notice %}}
 Alternatively, you can use the `--vault` [superflag's]({{< relref "deploy/cli-command-reference.md" >}}) options to enable encryption, as [explained below](#example-using-dgraph-cli-with-hashicorp-vault-configuration).
 
 ## Turn on Encryption
@@ -71,7 +73,7 @@ To use [Hashicorp Vault](https://www.vaultproject.io/), meet the following prere
        "cas": 0
      },
      "data": {
-       "enc_key": "1234567890123456"
+       "enc_key": "qIvHQBVUpzsOp74PmMJjHAOfwIA1e6zm%"
      }
    }
    ```   

--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -6,13 +6,10 @@ title = "Dgraph Releases"
   weight = 14
 +++
 
-The latest Dgraph release is the v21.03 series.
+The latest Dgraph release is the v22.00 series.
 
-Dgraph releases starting with v20.03 follow
-[calendar versioning](https://calver.org). To learn more about our switch from
-semantic to calendar versioning, and why v2-v19 don't exist as a result of this
-switch, see our Blog post on the 
-[switch to calendar versioning](https://dgraph.io/blog/post/dgraph-calendar-versioning/).
+Dgraph releases starting v22.0.0 is following semver
+[See the post here](https://discuss.dgraph.io/t/dgraph-v22-0-0-rc1-20221003-release-candidate/).
 
 To learn about the latest releases and other important announcements, watch the
 [Announce][] category on Discuss.
@@ -23,15 +20,17 @@ To learn about the latest releases and other important announcements, watch the
 
  Dgraph Release Series | Current Release | Supported? | First Release Date | End of life
 -----------------------|-----------------|------------|--------------------|--------------
- v21.03.x              | [v21.03.0][]    | Yes        | March 2021         | March 2022
- v20.11.x              | [v20.11.0][]    | Yes        | December 2020      | December 2021
- v20.07.x              | [v20.07.3][]    | Yes        | July 2020          | July 2021
+ v22.0.x               | [v22.0.0][]     | Yes        | October 2022       | N/A
+ v21.12.x(discontinued)| [v21.12.0][]    | No         | December 2021      | December 2022
+ v21.03.x              | [v21.03.0][]    | Yes        | March 2021         | June 2023
+ v20.11.x              | [v20.11.0][]    | No         | December 2020      | December 2021
+ v20.07.x              | [v20.07.3][]    | No         | July 2020          | July 2021
  v20.03.x              | [v20.03.7][]    | No         | March 2020         | March 2021
  v1.2.x                | [v1.2.8][]      | No         | January 2020       | January 2021
  v1.1.x                | [v1.1.1][]      | No         | January 2020       | January 2021
  v1.0.x                | [v1.0.18][]     | No         | December 2017      | March 2020
 
-
+[v22.0.0]: https://discuss.dgraph.io/t/dgraph-v22-0-0-is-now-ga/17889
 [v21.03.0]: https://discuss.dgraph.io/t/release-notes-v21-03-0-resilient-rocket/13587
 [v20.11.0]: https://discuss.dgraph.io/t/release-notes-v20-11-0-tenacious-tchalla/11942
 [v20.07.3]: https://discuss.dgraph.io/t/dgraph-v20-07-3-release/12107

--- a/content/tutorial-8/index.md
+++ b/content/tutorial-8/index.md
@@ -1568,7 +1568,7 @@ to refresh our previous discussions around using the `@filter` directive.
 {
   find_hotel(func: near(location, [-122.479784,37.82883295],7000)) {
     name
-    has_type @filter(eq(loc_type, "hotel")){
+    has_type @filter(eq(loc_type, "Hotel")){
       loc_type 
     }
   }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,6 +40,7 @@ MAJOR_VERSIONS=(
 )
 
 VERSIONS_ARRAY=(
+  'v22.0'
   ${MAJOR_VERSIONS:0}
   ${MAJOR_VERSIONS[@]:1}
   'main'


### PR DESCRIPTION
1. fix a typo error in the [DQL tutorial-8](https://dgraph.io/docs/tutorial-8/) about geo data. the filter argument in the code sample, "`hotel`" is changed to "`Hotel`" in consistent with the given sample data.
   ```go
   1571 - has_type @filter(eq(loc_type, "hotel")){
   1571 + has_type @filter(eq(loc_type, "Hotel")){
   ```