### PR TITLE
Docs(other): fix a typo error, change DQL filter argument value "hotel" to "Hotel".

### DIFF
--- a/content/tutorial-8/index.md
+++ b/content/tutorial-8/index.md
@@ -1568,7 +1568,7 @@ to refresh our previous discussions around using the `@filter` directive.
 {
   find_hotel(func: near(location, [-122.479784,37.82883295],7000)) {
     name
-    has_type @filter(eq(loc_type, "hotel")){
+    has_type @filter(eq(loc_type, "Hotel")){
       loc_type 
     }
   }


### PR DESCRIPTION
1. fix a typo error in the [DQL tutorial-8](https://dgraph.io/docs/tutorial-8/) about geo data. the filter argument in the code sample, "`hotel`" is changed to "`Hotel`" in consistent with the given sample data.
   ```go
   1571 - has_type @filter(eq(loc_type, "hotel")){
   1571 + has_type @filter(eq(loc_type, "Hotel")){
   ```