### PR TITLE
docs(metrics): Use correct Badger metrics. (#239)

### DIFF
--- a/content/deploy/metrics.md
+++ b/content/deploy/metrics.md
@@ -36,13 +36,16 @@ not interact directly with the filesystem. Instead it relies on
 
  Metric                          	 | Description
  -------                          	 | -----------
- `badger_v3_disk_reads_total`        | Total count of disk reads in Badger.
- `badger_v3_disk_writes_total`       | Total count of disk writes in Badger.
- `badger_v3_gets_total`              | Total count of calls to Badger's `get`.
- `badger_v3_memtable_gets_total`     | Total count of memtable accesses to Badger's `get`.
- `badger_v3_puts_total`              | Total count of calls to Badger's `put`.
- `badger_v3_read_bytes`              | Total bytes read from Badger.
- `badger_v3_written_bytes`           | Total bytes written to Badger.
+ `badger_disk_reads_total`        | Total count of disk reads in Badger.
+ `badger_disk_writes_total`       | Total count of disk writes in Badger.
+ `badger_gets_total`              | Total count of calls to Badger's `get`.
+ `badger_memtable_gets_total`     | Total count of memtable accesses to Badger's `get`.
+ `badger_puts_total`              | Total count of calls to Badger's `put`.
+ `badger_read_bytes`              | Total bytes read from Badger.
+ `badger_lsm_bloom_hits_total`    | Total number of LSM tree bloom hits.
+ `badger_written_bytes`           | Total bytes written to Badger.
+ `badger_lsm_size_bytes`          | Total size in bytes of the LSM tree.
+ `badger_vlog_size_bytes`         | Total size in bytes of the value log.
 
 ## Go Metrics
 


### PR DESCRIPTION
This PR reflects the update to Dgraph metrics made in https://github.com/dgraph-io/dgraph/pull/7507:

> This renames the Badger metrics in the /metrics endpoint to remove the
> Badger version in the metric names. This allows the metric name to
> remain the same across Badger major versions.
> 
> | Previous Name                   | New Name                     |
> | ------------------------------- | ---------------------------- |
> | badger_v3_disk_reads_total      | badger_disk_reads_total      |
> | badger_v3_disk_writes_total     | badger_disk_writes_total     |
> | badger_v3_read_bytes            | badger_read_bytes            |
> | badger_v3_written_bytes         | badger_written_bytes         |
> | badger_v3_lsm_bloom_hits_total  | badger_lsm_bloom_hits_total  |
> | badger_v3_gets_total            | badger_gets_total            |
> | badger_v3_puts_total            | badger_puts_total            |
> | badger_v3_memtable_gets_total   | badger_memtable_gets_total   |
> | badger_v3_lsm_size_bytes        | badger_lsm_size_bytes        |
> | badger_v3_vlog_size_bytes       | badger_vlog_size_bytes       |

This doc change needs to be cherry-picked to release/v21.03.
