### PR TITLE
Add information about using "p" dir coming from other Dgraph clusters…

### DIFF
--- a/content/deploy/fast-data-loading/bulk-loader.md
+++ b/content/deploy/fast-data-loading/bulk-loader.md
@@ -272,6 +272,46 @@ I1227 13:27:53.959671   29781 draft.go:571] Creating snapshot at index: 34. Read
 ```
 Note that `snapshot at index` value must be the same within the same Alpha group and `ReadTs` must be the same value within and among all the Alpha groups.
 
+### Using "p" directories coming from different Dgraph clusters
+
+In some cases, you might want to use the `p` directory from an existing Dgraph cluster when creating a new cluster. You can do this by copying the `p` directory from your current Dgraph cluster into the new cluster, but you will need to perform an additional step before starting the Alpha nodes in the new cluster, as described below. 
+
+After starting your Zero nodes, you need to increase the Zero's timestamp by sending the following `curl` request to the Zero leader node:
+
+```
+curl "zero_address:port/assign?what=timestamps&num=X" #with X = high number e.g. 100000 or higher
+```
+This will print the following message:
+
+```
+{"startId":"1","endId":"10000000","readOnly":"0"}
+```
+Now you need to confirm whether this timestamp has been increased as expected. You can do this by sending a `curl` request to the zero `/state` endpoint, as follows:
+
+```
+curl zero-address:port/state | jq
+```
+At the end of the response, look for the value shown for `"maxTxnTs"`. This value should be greater than or equal to the timestamp you assigned in the previous `curl` request, as shown in the following example:
+
+```json
+  "maxLeaseId": "0",
+  "maxTxnTs": "10010000",
+  "maxRaftId": "0",
+  "removed": [],
+  "cid": "47285b0d-6223-421e-aab5-e6910620a8ed",
+  "license": {
+    "user": "",
+    "maxNodes": "18446744073709551615",
+    "expiryTs": "1619041648",
+    "enabled": true
+  }
+```
+Now, start your Alpha nodes and check that the Snapshot created has a `ReadTs` value that's greater than or equal to the `"maxTxnTs"` value you viewed in the previous step.
+
+```
+I0322 14:52:40.858626 2885131 draft.go:606] Creating snapshot at Index: 180, ReadTs: 10000011
+```
+
 ## Enterprise Features
 
 ### Multi-tenancy (Enterprise Feature)


### PR DESCRIPTION
This pr explains how to properly use a `p` directory that is coming from a different cluster. This adds instruction on how to let Zero correctly manage the `p` directory by increasing the timestamp