### PR TITLE
move type-system

### DIFF
--- a/content/dql/type-system.md
+++ b/content/dql/type-system.md
@@ -1,9 +1,9 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
 title = "Type System"
-weight = 21
+weight = 3
 [menu.main]
-    parent = "query-language"
+    parent = "dql"
 +++
 
 Dgraph supports a type system that can be used to categorize nodes and query

--- a/content/howto/giving-nodes-type.md
+++ b/content/howto/giving-nodes-type.md
@@ -7,4 +7,4 @@ weight = 5
 +++
 
 It's often useful to give the nodes in a graph *types* (also commonly referred
-to as *labels* or *kinds*). You can do so using the [type system]({{< relref "query-language/type-system.md" >}}).
+to as *labels* or *kinds*). You can do so using the [type system]({{< relref "type-system.md" >}}).

--- a/content/mutations/json-mutation-format.md
+++ b/content/mutations/json-mutation-format.md
@@ -11,7 +11,7 @@ be expressed in a more natural way. It also eliminates the need for apps to
 have custom serialization code, since most languages already have a JSON
 marshaling library.
 
-When Dgraph receives a mutation as a JSON object, it first converts it into an 
+When Dgraph receives a mutation as a JSON object, it first converts it into an
 internal edge format that is then processed into Dgraph.
 
 > JSON  -> Edges -> Posting list \
@@ -62,9 +62,9 @@ In this case, the assigned UIDs map would have a key called `diggy` with the val
 assigned to it.
 
 ### Forbidden values
- 
+
 {{% notice "note" %}}
-When using JSON mutations, the following string values are not accepted: `uid( )`, `val( )` 
+When using JSON mutations, the following string values are not accepted: `uid( )`, `val( )`
 {{% /notice %}}
 
 For example, the following JSON can't be processed by Dgraph:
@@ -256,7 +256,7 @@ If no predicates are specified, then all of the node's known outbound edges (to
 other nodes and to literal values) are deleted (corresponding to deleting `S *
 *`). The predicates to delete are derived using the type system. Refer to the
 [RDF format]({{< relref "mutations/delete.md" >}}) documentation and the section on the
-[type system]({{< relref "query-language/type-system.md" >}}) for more
+[type system]({{< relref "type-system.md" >}}) for more
 information:
 
 ```JSON

--- a/content/query-language/expand-predicates.md
+++ b/content/query-language/expand-predicates.md
@@ -7,7 +7,7 @@ weight = 14
 +++
 
 The `expand()` function can be used to expand the predicates out of a node. To
-use `expand()`, the [type system]({{< relref "query-language/type-system.md" >}}) is required.
+use `expand()`, the [type system]({{< relref "type-system.md" >}}) is required.
 Refer to the section on the type system to check how to set the types
 nodes. The rest of this section assumes familiarity with that section.
 

--- a/content/tutorials/index.md
+++ b/content/tutorials/index.md
@@ -4,7 +4,7 @@ title = "Tutorials - Get Started with Dgraph series"
   name = "Tutorials"
   identifier = "tutorials"
   parent = "dql"
-  weight = 3
+  weight = 8
 +++
 
 {{% notice "note" %}}


### PR DESCRIPTION
Move type-system as a concept page in DQL rather than a part of the DQL syntax.
type system will be referenced in DQL syntax page when explaining why you may have "dgraph.type" predicate in mutation.