### PR TITLE
[REVAMP]: move predicate types (ex schema) to DQL section

### DIFF
--- a/content/clients/java.md
+++ b/content/clients/java.md
@@ -10,7 +10,7 @@ A minimal implementation for a Dgraph client for Java 1.8 and above, using [gRPC
 This client follows the [Dgraph Go client]({{< relref "go.md" >}}) closely.
 
 {{% notice "tip" %}}
-The official Java client [can be found here](https://github.com/dgraph-io/dgraph4j). 
+The official Java client [can be found here](https://github.com/dgraph-io/dgraph4j).
 Follow the [install instructions](https://github.com/dgraph-io/dgraph4j#download) to get it up and running.
 {{% /notice %}}
 
@@ -35,7 +35,7 @@ be found in the [Using the Asynchronous Client](#using-the-asynchronous-client) 
 ## Using the Synchronous Client
 
 {{% notice "tip" %}}
-You can find a [DgraphJavaSample](https://github.com/dgraph-io/dgraph4j/tree/master/samples/DgraphJavaSample) project, 
+You can find a [DgraphJavaSample](https://github.com/dgraph-io/dgraph4j/tree/master/samples/DgraphJavaSample) project,
 which contains an end-to-end working example of how to use the Java client.
 {{% /notice %}}
 
@@ -154,7 +154,7 @@ dgraphClient.alter(operation);
 Starting Dgraph version 20.03.0, indexes can be computed in the background.
 You can call the function `setRunInBackground(true)` as shown below before
 calling `alter`. You can find more details
-[here]({{< relref "/query-language/schema.md#indexes-in-background" >}}).
+[here]({{< relref "/predicate-types.md#indexes-in-background" >}}).
 
 ```java
 String schema = "name: string @index(exact) .";
@@ -357,7 +357,7 @@ txn.doRequest(request);
 
 ### Running a Query with RDF response
 
-You can get query results as an RDF response by calling either `queryRDF()` or `queryRDFWithVars()`. 
+You can get query results as an RDF response by calling either `queryRDF()` or `queryRDFWithVars()`.
 The response contains the `getRdf()` method, which will provide the RDF encoded output.
 
 **Note**: If you are querying for `uid` values only, use a JSON format response
@@ -510,7 +510,7 @@ Here is the asynchronous version of the code above, which runs a query.
 
 ```java
 // Query
-String query = 
+String query =
 "query all($a: string){\n" +
 "  all(func: eq(name, $a)) {\n" +
 "    name\n" +

--- a/content/clients/javascript/grpc.md
+++ b/content/clients/javascript/grpc.md
@@ -112,7 +112,7 @@ await dgraphClient.alter(op);
 Starting Dgraph version 20.03.0, indexes can be computed in the background.
 You can set `setRunInBackground` field of the `Operation` object to `true`
 before passing it to the `DgraphClient#alter(Operation)` method. You can find more details
-[here]({{< relref "/query-language/schema.md#indexes-in-background" >}}).
+[here]({{< relref "predicate-types.md#indexes-in-background" >}}).
 
 ```js
 const schema = "name: string @index(exact) .";

--- a/content/clients/python.md
+++ b/content/clients/python.md
@@ -87,7 +87,7 @@ client.alter(op)
 Starting with Dgraph version 20.03.0, indexes can be computed in the background.
 You can set the `run_in_background` field of `pydgraph.Operation` to `True`
 before passing it to the `Alter` function. You can find more details
-[here]({{< relref "/query-language/schema.md#indexes-in-background" >}}).
+[here]({{< relref "/predicate-types.md#indexes-in-background" >}}).
 
 ```python
 schema = 'name: string @index(exact) .'

--- a/content/deploy/dgraph-administration.md
+++ b/content/deploy/dgraph-administration.md
@@ -87,7 +87,7 @@ This would allow admin operations from hosts with hostnames `admin-bastion` and 
 By default, you can perform mutation operations for any predicate.
 If the predicate in mutation doesn't exist in the schema,
 the predicate gets added to the schema with an appropriate
-[Dgraph Type]({{< relref "query-language/schema.md" >}}).
+[Dgraph Type]({{< relref "predicate-types.md" >}}).
 
 You can use `--limit "mutations=disallow"` to disable all mutations,
 which is set to `allow` by default.

--- a/content/deploy/dgraph-alpha.md
+++ b/content/deploy/dgraph-alpha.md
@@ -76,6 +76,6 @@ Here’s an example of JSON returned from the above query:
 - `group`: Group assigned based on the replication factor. Read more [here]({{< relref "/deploy/cluster-setup.md" >}}).
 - `lastEcho`: Last time, in Unix epoch, when the instance was contacted by another Alpha or Zero server.
 - `ongoing`: List of ongoing operations in the background.
-- `indexing`: List of predicates for which indexes are built in the background. Read more [here]({{< relref "/query-language/schema.md#indexes-in-background" >}}).
+- `indexing`: List of predicates for which indexes are built in the background. Read more [here]({{< relref "/predicate-types.md#indexes-in-background" >}}).
 
 The same information (except `ongoing` and `indexing`) is available from the `/health` and `/health?all` endpoints of Alpha server.

--- a/content/design-concepts/concepts.md
+++ b/content/design-concepts/concepts.md
@@ -17,7 +17,7 @@ Both the terminologies get used interchangeably in our code. Dgraph considers ed
 i.e. from `Subject -> Object`. This is the direction that the queries would be run.
 
 {{% notice "tip" %}}Dgraph can automatically generate a reverse edge. If the user wants to run
-queries in that direction, they would need to define the [reverse edge]({{< relref "query-language/schema.md#reverse-edges" >}})
+queries in that direction, they would need to define the [reverse edge]({{< relref "predicate-types.md#reverse-edges" >}})
 as part of the schema.{{% /notice %}}
 
 Internally, the RDF N-Quad gets parsed into this format.

--- a/content/dql/predicate-types.md
+++ b/content/dql/predicate-types.md
@@ -1,9 +1,9 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
-title = "Schema"
-weight = 20
+title = "Predicate types"
+weight = 3
 [menu.main]
-    parent = "query-language"
+    parent = "dql"
 +++
 
 For each predicate, the schema specifies the target's type.  If a predicate `p` has type `T`, then for all subject-predicate-object triples `s p o` the object `o` is of schema type `T`.
@@ -258,7 +258,7 @@ email: string @index(exact) @noconflict .
 
 Dgraph supports a number of [RDF types in mutations]({{< relref "mutations/language-rdf-types.md" >}}).
 
-As well as implying a schema type for a [first mutation]({{< relref "query-language/schema.md" >}}), an RDF type can override a schema type for storage.
+As well as implying a schema type for a first mutation, an RDF type can override a schema type for storage.
 
 If a predicate has a schema type and a mutation has an RDF type with a different underlying Dgraph type, the convertibility to schema type is checked, and an error is thrown if they are incompatible, but the value is stored in the RDF type's corresponding Dgraph type.  Query results are always returned in schema type.
 
@@ -381,7 +381,7 @@ Incorrect index choice can impose performance penalties and an increased
 transaction conflict rate. Use only the minimum number of and simplest indexes
 that your application needs.
 {{% /notice %}}
- 
+
 ### DateTime Indices
 
 The indices available for `dateTime` are as follows.

--- a/content/dql/type-system.md
+++ b/content/dql/type-system.md
@@ -1,7 +1,7 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
-title = "Type System"
-weight = 3
+title = "Node types"
+weight = 4
 [menu.main]
     parent = "dql"
 +++

--- a/content/enterprise-features/access-control-lists.md
+++ b/content/enterprise-features/access-control-lists.md
@@ -522,7 +522,7 @@ mutation {
 }
 ```
 
-In case you have [reverse edges]({{< relref "query-language/schema.md#reverse-edges" >}}), they have to be given the permission to the group as well
+In case you have [reverse edges]({{< relref "predicate-types.md#reverse-edges" >}}), they have to be given the permission to the group as well
 
 ```graphql
 mutation {

--- a/content/graphql/dgraph/index.md
+++ b/content/graphql/dgraph/index.md
@@ -10,7 +10,7 @@ weight = 13
 
 If you have an existing Dgraph instance and want to also expose GraphQL, you need to add a GraphQL schema that maps to your Dgraph schema.  You don't need to expose your entire Dgraph schema as GraphQL, but do note that adding a GraphQL schema can alter the Dgraph schema.
 
-Dgraph's native DQL syntax allows type and edge names that aren't valid in GraphQL; so, you'll often need to expose valid GraphQL names. Dgraph permits special characters, including Unicode characters from a variety of  languages (see [Predicate name rules]({{< relref "query-language/schema.md#predicate-name-rules">}})). Conversely, the [GraphQL specification on naming](https://spec.graphql.org/June2018/#sec-Names) requires that entity names, including types and fields (predicate), are composed of ASCII characters and generated as follows: `/[_A-Za-z][_0-9A-Za-z]*/`.
+Dgraph's native DQL syntax allows type and edge names that aren't valid in GraphQL; so, you'll often need to expose valid GraphQL names. Dgraph permits special characters, including Unicode characters from a variety of  languages (see [Predicate name rules]({{< relref "predicate-types.md#predicate-name-rules">}})). Conversely, the [GraphQL specification on naming](https://spec.graphql.org/June2018/#sec-Names) requires that entity names, including types and fields (predicate), are composed of ASCII characters and generated as follows: `/[_A-Za-z][_0-9A-Za-z]*/`.
 
 {{% notice "note" %}}
 Be careful with mapping to an existing Dgraph instance. Updating the GraphQL schema will also update the underlying Dgraph schema. 

--- a/content/mutations/language-rdf-types.md
+++ b/content/mutations/language-rdf-types.md
@@ -46,4 +46,4 @@ The supported [RDF datatypes](https://www.w3.org/TR/rdf11-concepts/#section-Data
 | &#60;http&#58;//www.w3.org/2001/XMLSchema#float&#62;            | `float`          |
 
 
-See the section on [RDF schema types]({{< relref "query-language/schema.md#rdf-types" >}}) to understand how RDF types affect mutations and storage.
+See the section on [RDF schema types]({{< relref "predicate-types.md#rdf-types" >}}) to understand how RDF types affect mutations and storage.

--- a/content/query-language/count.md
+++ b/content/query-language/count.md
@@ -28,7 +28,7 @@ Query Example: The number of films acted in by each actor with `Orlando` in thei
 
 Count can be used at root and [aliased]({{< relref "query-language/alias.md" >}}).
 
-Query Example: Count of directors who have directed more than five films.  When used at the query root, the [count index]({{< relref "query-language/schema.md#count-index" >}}) is required.
+Query Example: Count of directors who have directed more than five films.  When used at the query root, the [count index]({{< relref "predicate-types.md#count-index" >}}) is required.
 
 {{< runnable >}}
 {

--- a/content/query-language/facets.md
+++ b/content/query-language/facets.md
@@ -120,7 +120,7 @@ All facets on an edge are queried with `@facets`.
 
 ## Facets i18n
 
-Facets keys and values can use language-specific characters directly when mutating. But facet keys need to be enclosed in angle brackets `<>` when querying. This is similar to predicates. See [Predicates i18n]({{< relref "query-language/schema.md#predicates-i18n" >}}) for more info.
+Facets keys and values can use language-specific characters directly when mutating. But facet keys need to be enclosed in angle brackets `<>` when querying. This is similar to predicates. See [Predicates i18n]({{< relref "predicate-types.md#predicates-i18n" >}}) for more info.
 
 {{% notice "note" %}}Dgraph supports [Internationalized Resource Identifiers](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier) (IRIs) for facet keys when querying.{{% /notice  %}}
 

--- a/content/query-language/functions.md
+++ b/content/query-language/functions.md
@@ -12,7 +12,7 @@ Functions allow filtering based on properties of nodes or [variables]({{<relref 
 {{% /notice %}}
 
 Comparison functions (`eq`, `ge`, `gt`, `le`, `lt`) in the query root (aka `func:`) can only
-be applied on [indexed predicates]({{< relref "query-language/schema.md#indexing" >}}). Since v1.2, comparison functions
+be applied on [indexed predicates]({{< relref "predicate-types.md#indexing" >}}). Since v1.2, comparison functions
 can now be used on [@filter]({{<relref "query-language/graphql-fundamentals.md#applying-filters" >}}) directives even on predicates
 that have not been indexed.
 Filtering on non-indexed predicates can be slow for large datasets, as they require
@@ -364,7 +364,7 @@ Query Example: Movies with directors with `Steven` in `name` and have directed m
 
 
 
-Query Example: A movie in each genre that has over 30000 movies.  Because there is no order specified on genres, the order will be by UID.  The [count index]({{< relref "query-language/schema.md#count-index">}}) records the number of edges out of nodes and makes such queries more .
+Query Example: A movie in each genre that has over 30000 movies.  Because there is no order specified on genres, the order will be by UID.  The [count index]({{< relref "predicate-types.md#count-index">}}) records the number of edges out of nodes and makes such queries more .
 
 {{< runnable >}}
 {

--- a/content/query-language/sorting.md
+++ b/content/query-language/sorting.md
@@ -18,7 +18,7 @@ Sortable Types: `int`, `float`, `String`, `dateTime`, `default`
 
 Results can be sorted in ascending order (`orderasc`) or descending order (`orderdesc`) by a predicate or variable.
 
-For sorting on predicates with [sortable indices]({{< relref "query-language/schema.md#sortable-indices">}}), Dgraph sorts on the values and with the index in parallel and returns whichever result is computed first.
+For sorting on predicates with [sortable indices]({{< relref "predicate-types.md#sortable-indices">}}), Dgraph sorts on the values and with the index in parallel and returns whichever result is computed first.
 
 {{% notice "note" %}}
 Dgraph returns `null` values at the end of the results, irrespective of their sort. This behavior is consistent across indexed and non-indexed sorts.


### PR DESCRIPTION
update all references and use shorter reference.
