### PR TITLE
Docs (Binary backups): Online restore, remove rouge '

### DIFF
--- a/content/enterprise-features/binary-backups.md
+++ b/content/enterprise-features/binary-backups.md
@@ -507,7 +507,7 @@ endpoint with the following format:
 mutation{
   restore(input:{
     location: "/path/to/backup/directory",
-    backupId: "id_of_backup_to_restore"'
+    backupId: "id_of_backup_to_restore"
   }){
     message
     code


### PR DESCRIPTION
Simple typo fix.

---

Might be nice to add an example of how to use the /admin endpoint?
Like:
```
curl -X POST localhost:8080/admin -H "Content-type: application/graphql" --data-binary '@admin-mutation'
```
File admin-mutation:
```
mutation{
  restore(input:{
    location: "/dgraph/backup",
    backupId: "ecstatic_germain2"
  }){
    message
    code
  }
}
```
