### PR TITLE
docs(typo): fixed typo in JSON mutation docs

### DIFF
--- a/content/dql/dql-syntax/json-mutation-format.md
+++ b/content/dql/dql-syntax/json-mutation-format.md
@@ -206,7 +206,7 @@ For example, to remove the predicate `name` from node  `0xfffd8d72745f0691` :
 
 ## Deleting relationship
 
-A relationhsip can be defined with a cardinality of 1 or many (list).
+A relationship can be defined with a cardinality of 1 or many (list).
 Setting a relationship to `null` removes all the relationships.
 
 ```JSON
@@ -217,7 +217,7 @@ Setting a relationship to `null` removes all the relationships.
 ```
 
 
-To delete a single relationhsip in a list, you must specify the target node of the relationship.
+To delete a single relationship in a list, you must specify the target node of the relationship.
 
 ```dql
 {


### PR DESCRIPTION
Noticed a minor typo when reading through the JSON mutation docs, thought I'd submit a quick PR to fix it.

Thanks!