### PR TITLE
remove reference to /admin/{backup,export} endpoints

### DIFF
--- a/content/deploy/admin/dgraph-administration.md
+++ b/content/deploy/admin/dgraph-administration.md
@@ -24,10 +24,8 @@ Admin endpoints usually start with the `/admin` path. The current list of admin
 endpoints includes the following:
 
 * `/admin`
-* `/admin/backup`
 * `/admin/config/cache_mb`
 * `/admin/draining`
-* `/admin/export`
 * `/admin/shutdown`
 * `/admin/schema`
 * `/admin/schema/validate`

--- a/content/deploy/cli-command-reference.md
+++ b/content/deploy/cli-command-reference.md
@@ -637,7 +637,7 @@ help listing shown when you run `dgraph restore --help`:
 ```shell
 Restore loads objects created with the backup feature in Dgraph Enterprise Edition (EE).
 
-Backups are originated from HTTP at /admin/backup, then can be restored using CLI restore
+Backups taken using the GraphQL API can be restored using CLI restore
 command. Restore is intended to be used with new Dgraph clusters in offline state.
 
 The --location flag indicates a source URI with Dgraph backup objects. This URI supports all

--- a/content/deploy/dgraph-alpha.md
+++ b/content/deploy/dgraph-alpha.md
@@ -10,8 +10,6 @@ Dgraph Alpha provides several HTTP endpoints for administrators, as follows:
 
 * `/health?all` returns information about the health of all the servers in the cluster.
 * `/admin/shutdown` initiates a proper [shutdown]({{< relref "dgraph-administration.md#shutting-down-database" >}}) of the Alpha.
-* `/admin/export` initiates a data [export]({{< relref "dgraph-administration.md#exporting-database" >}}). The exported data will be
-encrypted if the alpha instance was configured with an encryption key file.
 
 By default the Alpha listens on `localhost` for admin actions (the loopback address only accessible from the same machine). The `--bindall=true` option binds to `0.0.0.0` and thus allows external connections.
 

--- a/content/deploy/security/tls-configuration.md
+++ b/content/deploy/security/tls-configuration.md
@@ -349,16 +349,17 @@ succeed.
 
 ## Using Curl with Client authentication
 
-When TLS is enabled, `curl` requests to Dgraph will need some specific options to work.  For instance (for an export request):
+When TLS is enabled, `curl` requests to Dgraph will need some specific options to work.
+For instance (for changing draining mode):
 
 ```
-curl --silent https://localhost:8080/admin/export
+curl --silent https://localhost:8080/admin/draining
 ```
 
 If you are using `curl` with [Client Authentication](#client-authentication-options) set to `REQUIREANY` or `REQUIREANDVERIFY`, you will need to provide the client certificate and private key.  For instance (for an export request):
 
 ```
-curl --silent --cacert ./tls/ca.crt --cert ./tls/client.dgraphuser.crt --key ./tls/client.dgraphuser.key https://localhost:8080/admin/export
+curl --silent --cacert ./tls/ca.crt --cert ./tls/client.dgraphuser.crt --key ./tls/client.dgraphuser.key https://localhost:8080/admin/draining
 ```
 
 Refer to the `curl` documentation for further information on its TLS options.


### PR DESCRIPTION
The PR https://github.com/dgraph-io/dgraph/pull/8554 removes these two endpoints.