### PR TITLE
Docs(Unofficial Clients): added new C# unofficial client

### DIFF
--- a/content/dql/clients/unofficial-clients.md
+++ b/content/dql/clients/unofficial-clients.md
@@ -29,5 +29,8 @@ These third-party clients are contributed by the community and are not officiall
 - https://github.com/Swoorup/dgraph-rs
 - https://github.com/selmeci/dgraph-tonic
 
+## C#
+- https://github.com/schivei/dgraph4net - DQL Client with migration management
+
 
 


### PR DESCRIPTION
Added dgraph4net C# Unofficial client

 - In past, under v20, it's is present, but not commited to new
 - In the new version of dgraph4net, only .NET 7+ is supported
   - v23 are supported
   - Migrations are supported with Dgraph4Net.Tools
   - Lower size compared to old version
   - Now we use Fluent mapping instead of Attributes mapping
   - Better performance to mapping
   - Mapping is used to serialize / deserialize DQL responses

Our documentation for checking [https://github.com/schivei/dgraph4net/blob/master/README.md](https://github.com/schivei/dgraph4net/blob/master/README.md)