### PR TITLE
Docs(other): Fix mutations=strict typo in dgraph-administration.md

### DIFF
--- a/content/deploy/admin/dgraph-administration.md
+++ b/content/deploy/admin/dgraph-administration.md
@@ -102,7 +102,7 @@ Before performing a mutation on a predicate that doesn't exist in the schema,
 you need to perform an alter operation with that predicate and its schema type.
 
 ```sh
-dgraph alpha --limit "mutation=strict; mutations-nquad=1000000"
+dgraph alpha --limit "mutations=strict; mutations-nquad=1000000"
 ```
 
 ## Secure Alter Operations


### PR DESCRIPTION
Fix typo `mutation=strict` -> `mutations=strict`


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from main to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `main` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `main` branch when you can, so that we only cherry-pick out of `main`, not into `main`.
-->
