### PR TITLE
Update _index.md to clarify cloud security on by default

### DIFF
--- a/content/graphql/security/_index.md
+++ b/content/graphql/security/_index.md
@@ -11,14 +11,14 @@ When you deploy a GraphQL schema, Dgraph automatically generates the query and m
 
 
 Dgraph's GraphQL authorization features let you specify : 
-- if the client requires an API key or notif **anonymous access** is allowed to invoke a specific operation of the API.
+- if the client requires an API key or not. If **anonymous access** is allowed, read and write operations may be invoked without a key for specified types.
 - if a client must present an identity in the form of a **JWT token** to use the API.
 - **RBAC rules** (Role Based Access Control) at operation level based on the claims included in the client JWT token.
 - **ABAC rules** (Attribute Based Access COntrol) at data level using graph traversal queries.
 
 
 {{% notice "note" %}}
-By default all operations are accessible to anonymous clients, no JWT token is required and no authorization rules are applied.
+By default all operations are accessible to anonymous clients for on-premise (non-cloud); no JWT token is required and no authorization rules are applied. For cloud instances, anonymous access is off by default, and can be enabled via the cloud console.
 It is your responsibility to correctly configure the authorization for the ``/graphql`` endpoint.
 {{% /notice %}}
 


### PR DESCRIPTION
Changed the note (in a box) to say security is on for cloud. Also fixed typo.


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from main to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `main` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `main` branch when you can, so that we only cherry-pick out of `main`, not into `main`.
-->
