### PR TITLE
Docs(dgraph-glossary.md): Fixed hyperlink formatting in GraphQL section

### DIFF
--- a/content/dgraph-glossary.md
+++ b/content/dgraph-glossary.md
@@ -30,7 +30,7 @@ A facet represents a property of a [relationship](#relationship).
 A graph is a simple structure that maps relations between objects. In Dgraph terminology, the objects are [nodes](#node) and the connections between them are [relationships](#relationship).
 
 ### GraphQL ###
-GraphQL](https://graphql.org/) is a declarative language for querying data used by application developers to get the data they need using GraphQL APIs. GraphQL is an open standard with a robust ecosystem.  Dgraph supports the deployment of a GraphQL data model (GraphQL schema) and automatically exposes a GraphQL API endpoint accepting GraphQL queries.
+[GraphQL](https://graphql.org/) is a declarative language for querying data used by application developers to get the data they need using GraphQL APIs. GraphQL is an open standard with a robust ecosystem.  Dgraph supports the deployment of a GraphQL data model (GraphQL schema) and automatically exposes a GraphQL API endpoint accepting GraphQL queries.
 
 ### gRPC ###
 [gRPC](https://grpc.io/) is a high performance Remote Procedure Call (RPC) framework used by Dgraph to interface with clients. Dgraph has official gRPC clients for go, C#, Java, JavaScript and Python. Applications written in those language can perform mutations and queries inside transactions using Dgraph clients.


### PR DESCRIPTION
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from main to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `main` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `main` branch when you can, so that we only cherry-pick out of `main`, not into `main`.
-->
There's a tiny formatting issue in dgraph-glossary.md. This fixes it