### PR TITLE
Update release table

### DIFF
--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -6,7 +6,7 @@ title = "Dgraph Releases"
   weight = 14
 +++
 
-The latest Dgraph release is the v23.00 series.
+The latest Dgraph release is the v23.1 series.
 
 Dgraph releases starting v22.0.0 is following semver
 [See the post here](https://discuss.dgraph.io/t/dgraph-v22-0-0-rc1-20221003-release-candidate/).
@@ -18,25 +18,27 @@ To learn about the latest releases and other important announcements, watch the
 
 ## Release series
 
- Dgraph Release Series | Current Release | Supported? | First Release Date | End of life
------------------------|-----------------|------------|--------------------|--------------
- v23.0.x               | [v23.0.0][]     | Yes        | May 2023           | N/A
- v22.0.x               | [v22.0.2][]     | Yes        | October 2022       | N/A
- v21.12.x(discontinued)| v21.12.0        | No         | December 2021      | December 2022
- v21.03.x              | [v21.03.0][]    | Yes        | March 2021         | June 2023
- v20.11.x              | [v20.11.0][]    | No         | December 2020      | December 2021
- v20.07.x              | [v20.07.3][]    | No         | July 2020          | July 2021
- v20.03.x              | [v20.03.7][]    | No         | March 2020         | March 2021
- v1.2.x                | [v1.2.8][]      | No         | January 2020       | January 2021
- v1.1.x                | [v1.1.1][]      | No         | January 2020       | January 2021
- v1.0.x                | [v1.0.18][]     | No         | December 2017      | March 2020
+ Release               | First Release Date | End of Life
+-----------------------|--------------------|--------------
+ [v23.1][]             | October 2023       | April 2025
+ [v23.0][]             | May 2023           | November 2024
+ [v22.0][]             | October 2022       | April 2024
+ v21.12 (discontinued) | December 2021      | December 2022
+ [v21.03][]            | March 2021         | June 2023
+ [v20.11][]            | December 2020      | December 2021
+ [v20.07][]            | July 2020          | July 2021
+ [v20.03][]            | March 2020         | March 2021
+ [v1.2][]              | January 2020       | January 2021
+ [v1.1][]              | January 2020       | January 2021
+ [v1.0][]              | December 2017      | March 2020
 
-[v23.0.0]: https://discuss.dgraph.io/t/dgraph-release-v23-0-0-is-now-generally-available/18634
-[v22.0.2]: https://discuss.dgraph.io/t/dgraph-release-v22-0-2-is-now-generally-available/18117
-[v21.03.0]: https://discuss.dgraph.io/t/release-notes-v21-03-0-resilient-rocket/13587
-[v20.11.0]: https://discuss.dgraph.io/t/release-notes-v20-11-0-tenacious-tchalla/11942
-[v20.07.3]: https://discuss.dgraph.io/t/dgraph-v20-07-3-release/12107
-[v20.03.7]: https://discuss.dgraph.io/t/dgraph-v20-03-7-release/12077
-[v1.2.8]: https://discuss.dgraph.io/t/dgraph-v1-2-8-release/11183
-[v1.1.1]: https://discuss.dgraph.io/t/dgraph-v1-1-1-release/5664
-[v1.0.18]: https://discuss.dgraph.io/t/dgraph-v1-0-18-release/5663
+[v23.1]: https://discuss.dgraph.io/t/dgraph-23-1-0-is-generally-available-on-dgraph-cloud-dockerhub-and-github/18980
+[v23.0]: https://discuss.dgraph.io/t/dgraph-release-v23-0-0-is-now-generally-available/18634
+[v22.0]: https://discuss.dgraph.io/t/dgraph-release-v22-0-2-is-now-generally-available/18117
+[v21.03]: https://discuss.dgraph.io/t/release-notes-v21-03-0-resilient-rocket/13587
+[v20.11]: https://discuss.dgraph.io/t/release-notes-v20-11-0-tenacious-tchalla/11942
+[v20.07]: https://discuss.dgraph.io/t/dgraph-v20-07-3-release/12107
+[v20.03]: https://discuss.dgraph.io/t/dgraph-v20-03-7-release/12077
+[v1.2]: https://discuss.dgraph.io/t/dgraph-v1-2-8-release/11183
+[v1.1]: https://discuss.dgraph.io/t/dgraph-v1-1-1-release/5664
+[v1.0]: https://discuss.dgraph.io/t/dgraph-v1-0-18-release/5663


### PR DESCRIPTION
Updating the release table in docs to:
1. include the latest release (v23.1)
2. make the table more maintainable/default current
3. omit patch releases
