### PR TITLE
docs(dql): Updated schema alter from date, to datetime

### DIFF
--- a/content/dql/dql-get-started.md
+++ b/content/dql/dql-get-started.md
@@ -135,7 +135,7 @@ Alter the schema to add indexes on some of the data so queries can use term matc
 
 Set the index for the `release_date`:
 1.    Select `release_date` predicate.
-2.    Change the type to **date**
+2.    Change the type to **datetime**
 3.    Select **index** and choose **year** for the index type.
 4.    Click **Update** to apply the index on the `release-date` predicate.
 


### PR DESCRIPTION
<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from main to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `main` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `main` branch when you can, so that we only cherry-pick out of `main`, not into `main`.
-->

## Description

While following the https://dgraph.io/docs/dql/dql-get-started#step-4-alter-schema documentation I noticed that the described type for `release_date` was of type `date` not `datetime`.

It appears that in later versions of the Ratel UI (or perhaps it's always been?) `date` is now `datetime`. 

This PR modifies the documentation from `date` to `datetime`.

![image](https://github.com/dgraph-io/dgraph-docs/assets/86993591/656aea30-ece1-4514-be0f-543ccb067c5b)

## Notes

This is my first contribution to the dgraph docs repo, please let me know if there's anything else I can do to make this a better PR! 

Many thanks!


