### PR TITLE
Docs(GraphQL): Handler for firebase token claim

### DIFF
--- a/content/learn/developer/todo-app-tutorial/todo-firebase-jwt.md
+++ b/content/learn/developer/todo-app-tutorial/todo-firebase-jwt.md
@@ -179,8 +179,8 @@ export const AuthProvider = ({ children }) => {
       setLoading(false)
       setCurrentUser(user)
       if (user) {
-        addUserClaim({email: user.email})
-        const token = await user.getIdToken(); 
+        await addUserClaim({email: user.email})
+        const token = await user.getIdToken(true); 
         setIdToken(token);
       }
     });


### PR DESCRIPTION
When requesting to add a claim for the first time, it's possible that it may not be ready yet. Waiting for it will prevent errors. Additionally, Firebase might return a cached `idToken`, which can be forced using `(true)` as a parameter.


<!--
Title: Please use the following format for your PR title:  topic(area): details
- The "topic" should be one of the following: Docs, Nav or Chore
- The "area" is the feature (i.e., "GraphQL"), area of the docs (i.e., "Deployment"), or "Other" (for typo fixes and other bug-fix PRs). 
Sample Titles:
  Docs(GraphQL): Document the @deprecated annotation
  Chore(Other): cherry-pick updates from main to release/v20.11

Description: Please include the following in your PR description:
1. A brief, clear description of the change.
2. Link to any related PRs or discuss.dgraph.io posts.
3. If this PR corresponds to a JIRA issue, include "Fixes DOC-###" in the PR description.
3. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
4. If you are creating a PR in `main` and you know it needs to be cherry-picked to a release branch, please mention that in your PR description (for example: "cherry-pick to v20.07"). Cherry-pick PRs should reference the original PR.

Note: Create and edit docs in the `main` branch when you can, so that we only cherry-pick out of `main`, not into `main`.
-->
