### PR TITLE
chore(Other): Update go.md in dgraph docs

### DIFF
--- a/content/dql/clients/go.md
+++ b/content/dql/clients/go.md
@@ -257,7 +257,7 @@ whichever way is convenient.
 To use JSON, use the fields SetJson and DeleteJson, which accept a string
 representing the nodes to be added or removed respectively (either as a JSON map
 or a list). To use RDF, use the fields SetNquads and DeleteNquads, which accept
-a string representing the valid RDF triples (one per line) to added or removed
+a string representing the valid RDF triples (one per line) to be added or removed
 respectively. This protobuf object also contains the Set and Del fields which
 accept a list of RDF triples that have already been parsed into our internal
 format. As such, these fields are mainly used internally and users should use


### PR DESCRIPTION
Topic: Docs(Other): Fix the grammatical error in the documentation
Description:
1. The sentence in the documentation was grammatically incorrect and was causing confusion
```diff
- a string representing the valid RDF triples (one per line) to added or removed
+ a string representing the valid RDF triples (one per line) to be added or removed
```
The link to the page is: https://dgraph.io/docs/dql/clients/go/