### PR TITLE
chore(Other): Remove redundant word in go.md

### DIFF
--- a/content/dql/clients/go.md
+++ b/content/dql/clients/go.md
@@ -299,7 +299,7 @@ returns an error in case the transaction could not be committed.
 
 ## Complete Example
 
-This is an example from the [GoDoc](https://godoc.org/github.com/dgraph-io/dgo). It shows how to to create a `Node` with name `Alice`, while also creating her relationships with other nodes. 
+This is an example from the [GoDoc](https://godoc.org/github.com/dgraph-io/dgo). It shows how to create a `Node` with name `Alice`, while also creating her relationships with other nodes. 
 
 {{% notice "note" %}}
 `loc` predicate is of type `geo` and can be easily marshaled and unmarshaled into a Go struct. More such examples are present as part of the GoDoc.


### PR DESCRIPTION
Topic: Docs(Other): Remove redundant word `to` in the documentation
Description:

The word `to` in the documentation was redundant.
```diff
- This is an example from the [GoDoc](https://godoc.org/github.com/dgraph-io/dgo). It shows how to to create a `Node` with name `Alice`, while also creating her relationships with other nodes. 
+ This is an example from the [GoDoc](https://godoc.org/github.com/dgraph-io/dgo). It shows how to create a `Node` with name `Alice`, while also creating her relationships with other nodes.
```

The link to the page is: https://dgraph.io/docs/dql/clients/go/