### PR TITLE
docs(graphql): Update extensions description for new dql_query attribute

### DIFF
--- a/content/graphql/graphql-clients/endpoint/graphql-response.md
+++ b/content/graphql/graphql-clients/endpoint/graphql-response.md
@@ -123,6 +123,7 @@ The "extensions" field contains extra metadata for the request with metrics and 
 
 - `"touched_uids"`: The number of nodes that were touched to satisfy the request. This is a good metric to gauge the complexity of the query.
 - `"tracing"`: Displays performance tracing data in [Apollo Tracing][apollo-tracing] format. This includes the duration of the whole query and the duration of each operation.
+- `"dql_query"`: Optional, displays the translated DQL query Dgraph composed. This is only output when the GraphQL debug superflag `(--graphql "debug=true;")` is set.
 
 [apollo-tracing]: https://github.com/apollographql/apollo-tracing
 


### PR DESCRIPTION
Updates docs to include dql_query output in the extensions when the graphql debug superflag is set to true.

Only merge when/if [#9280](https://github.com/hypermodeinc/dgraph/pull/9280) is released.