### PR TITLE
Chore(Other): remove color from sidebar menu link style

### DIFF
--- a/docusaurus-docs/src/css/custom.css
+++ b/docusaurus-docs/src/css/custom.css
@@ -67,7 +67,6 @@
 
 /* Sidebar - istari-documentation style */
 .menu__link {
-  color: var(--ifm-color-primary-darkest);
   font-size: 0.8rem;
   font-weight: normal;
 }


### PR DESCRIPTION
The inactive text color for the side bar is dark red. This makes it hard to read in dark mode. 
This PR removes the color attribute of `menu__link`, that makes the color of inactive text white in dark mode and black in light mode, which is more legible.

